### PR TITLE
[ FEAT ] JWT 인증 필터와 spring security 설정 추가 및 개발 환경 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     // webclient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // spring-security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -52,17 +52,18 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     // aws s3 api
     implementation 'software.amazon.awssdk:s3:2.31.63'
-    // swagger
+    // dev : swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    // dev : java-faker
+    implementation('com.github.javafaker:javafaker:1.0.2') { exclude module: 'snakeyaml' }
+    implementation 'org.yaml:snakeyaml:2.0'
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     // test : h2 database
     testImplementation 'com.h2database:h2'
-    // test : java-faker
-    implementation('com.github.javafaker:javafaker:1.0.2') { exclude module: 'snakeyaml' }
-    implementation 'org.yaml:snakeyaml:2.0'
+    // test :
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/komentum/auth/AuthProperty.java
+++ b/src/main/java/com/komentum/auth/AuthProperty.java
@@ -2,7 +2,7 @@ package com.komentum.auth;
 
 public class AuthProperty {
 
-  public static final String ACCESS_TOKEN_PREFIX = "Bearer ";
+  public static final String ACCESS_TOKEN_PREFIX = "Bearer";
   public static final String ACCESS_TOKEN_HEADER = "Authorization";
   public static final Long ACCESS_TOKEN_EXPIRES_IN = 360000L;
   public static final Long REFRESH_TOKEN_EXPIRES_IN = 360000L;

--- a/src/main/java/com/komentum/auth/JwtUtils.java
+++ b/src/main/java/com/komentum/auth/JwtUtils.java
@@ -4,18 +4,17 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpRequest;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@Profile("auth")
 public class JwtUtils {
 
   private final Key SECRET_KEY;
@@ -92,6 +91,25 @@ public class JwtUtils {
   public String resolveJwtToken(HttpRequest request) {
     try {
       String authorization = request.getHeaders().getFirst(AuthProperty.ACCESS_TOKEN_HEADER);
+      if (authorization == null || !authorization.startsWith(AuthProperty.ACCESS_TOKEN_PREFIX)) {
+        return null;
+      }
+      return authorization.substring(AuthProperty.ACCESS_TOKEN_PREFIX.length());
+    } catch (Exception e) {
+      log.error(e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * extract token from HttpServletRequest
+   *
+   * @param request HttpServletRequest
+   * @return jwt token without prefix or null if token not exists
+   */
+  public String resolveJwtToken(HttpServletRequest request) {
+    try {
+      String authorization = request.getHeader(AuthProperty.ACCESS_TOKEN_HEADER);
       if (authorization == null || !authorization.startsWith(AuthProperty.ACCESS_TOKEN_PREFIX)) {
         return null;
       }

--- a/src/main/java/com/komentum/config/SwaggerConfig.java
+++ b/src/main/java/com/komentum/config/SwaggerConfig.java
@@ -1,13 +1,19 @@
 package com.komentum.config;
 
+import com.komentum.auth.AuthProperty;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("dev")
 public class SwaggerConfig {
 
   @Bean
@@ -15,14 +21,33 @@ public class SwaggerConfig {
     Server server = new Server();
     return new OpenAPI()
         .servers(List.of(server))
+        .addSecurityItem(getTokenSecurityRequirement())
+        .components(getTokenComponents())
         .info(info());
   }
 
-  @Bean
   public Info info() {
     return new Info()
         .title("Komentum Service")
         .description("Komentum service api test")
         .version("1.0.0");
+  }
+
+  public Components getTokenComponents() {
+    String name = "Bearer Token";
+    SecurityRequirement requirement = new SecurityRequirement().addList(name);
+    return new Components()
+        .addSecuritySchemes(name,
+            new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .scheme(AuthProperty.ACCESS_TOKEN_PREFIX)
+                .name(AuthProperty.ACCESS_TOKEN_HEADER)
+                .bearerFormat("JWT"));
+  }
+
+  public SecurityRequirement getTokenSecurityRequirement() {
+    String name = "Bearer Token";
+    return new SecurityRequirement().addList(name);
   }
 }

--- a/src/main/java/com/komentum/config/TestDataGenerator.java
+++ b/src/main/java/com/komentum/config/TestDataGenerator.java
@@ -1,6 +1,7 @@
 package com.komentum.config;
 
 import com.github.javafaker.Faker;
+import com.komentum.global.security.UserRole;
 import com.komentum.post.domain.Comment;
 import com.komentum.post.domain.Post;
 import com.komentum.post.domain.Prefer;
@@ -50,6 +51,7 @@ public class TestDataGenerator {
     for (int i = 0; i < size; i++) {
       User user = User.builder()
           .userEmail(faker.internet().emailAddress())
+          .role(UserRole.USER)
           .birth(LocalDate.now().minusYears(i))
           .gender(i % 2 == 0 ? Gender.male : Gender.female)
           .profileImg(faker.internet().image())

--- a/src/main/java/com/komentum/config/TestDataGenerator.java
+++ b/src/main/java/com/komentum/config/TestDataGenerator.java
@@ -20,10 +20,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("dev")
 @RequiredArgsConstructor
 public class TestDataGenerator {
 

--- a/src/main/java/com/komentum/global/security/CustomUserDetails.java
+++ b/src/main/java/com/komentum/global/security/CustomUserDetails.java
@@ -1,0 +1,36 @@
+package com.komentum.global.security;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class CustomUserDetails implements UserDetails {
+
+  private final UserRole userRole;
+
+  @Builder
+  public CustomUserDetails(UserRole userRole) {
+    this.userRole = userRole;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    List<String> authorities = new ArrayList<>(List.of(userRole.name()));
+    return authorities.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+  }
+
+  @Override
+  public String getPassword() {
+    return null;
+  }
+
+  @Override
+  public String getUsername() {
+    return null;
+  }
+}

--- a/src/main/java/com/komentum/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/komentum/global/security/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.komentum.global.security;
+
+import com.komentum.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  /**
+   * 데이터베이스에서 사용자가 존재하는지 확인 후, CustomUserDetails 반환
+   *
+   * @param userEmail 사용자 이메일
+   * @return 사용자가 없다면 null, 있다면 CustomUserDetails 반환
+   * @throws UsernameNotFoundException
+   */
+  @Override
+  public UserDetails loadUserByUsername(String userEmail) throws UsernameNotFoundException {
+    return userRepository.findByUserEmail(userEmail)
+        .map(res -> CustomUserDetails.builder().userRole(res.getRole()).build())
+        .orElse(null);
+  }
+}

--- a/src/main/java/com/komentum/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/komentum/global/security/JwtAuthFilter.java
@@ -1,0 +1,40 @@
+package com.komentum.global.security;
+
+import com.komentum.auth.JwtUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+  private final JwtUtils jwtUtils;
+  private final CustomUserDetailsService userDetailsService;
+
+  @Override
+  protected void doFilterInternal(@NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain filterChain) throws ServletException, IOException {
+    Optional.ofNullable(jwtUtils.resolveJwtToken(request)) // 요청에서 토큰 추출
+        .filter(jwtUtils::validateToken) // 추출된 토큰의 유효성 확인
+        .map(jwtUtils::getEmail) // 토큰에서 사용자 이메일 추출
+        .map(userDetailsService::loadUserByUsername) // 사용자 이메일을 통해 UserDetails 혹은 null을 받음
+        .ifPresent( // UserDetails가 null이 아니라면, 인증 정보를 SecurityContext에 저장
+            userDetails -> {
+              UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                  userDetails, null, userDetails.getAuthorities());
+              SecurityContextHolder.getContext().setAuthentication(authToken);
+            });
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/komentum/global/security/SecurityConfig.java
+++ b/src/main/java/com/komentum/global/security/SecurityConfig.java
@@ -1,0 +1,53 @@
+package com.komentum.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableConfigurationProperties(SecurityProperties.class)
+public class SecurityConfig {
+
+  private final JwtAuthFilter jwtAuthFilter;
+
+  private final SecurityProperties securityProperties;
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .cors(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+        .authorizeHttpRequests(auth -> {
+          auth.requestMatchers(securityProperties.getWhiteList()).permitAll();
+          auth.requestMatchers(HttpMethod.GET, securityProperties.getWhiteListGet()).permitAll();
+          auth.anyRequest().authenticated();
+        });
+    return http.build();
+  }
+
+  @Bean
+  public CorsFilter corsFilter() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowCredentials(true);
+    config.addAllowedHeader("*");
+    config.addAllowedMethod("*");
+    config.addAllowedOriginPattern("*");
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return new CorsFilter(source);
+  }
+}

--- a/src/main/java/com/komentum/global/security/SecurityProperties.java
+++ b/src/main/java/com/komentum/global/security/SecurityProperties.java
@@ -1,0 +1,15 @@
+package com.komentum.global.security;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "security")
+public class SecurityProperties {
+
+  private final String[] whiteList;
+  private final String[] whiteListGet;
+}
+

--- a/src/main/java/com/komentum/global/security/UserRole.java
+++ b/src/main/java/com/komentum/global/security/UserRole.java
@@ -1,0 +1,7 @@
+package com.komentum.global.security;
+
+public enum UserRole {
+  GUEST,
+  USER,
+  ADMIN;
+}

--- a/src/main/java/com/komentum/theme/utils/S3FileManager.java
+++ b/src/main/java/com/komentum/theme/utils/S3FileManager.java
@@ -1,6 +1,7 @@
 package com.komentum.theme.utils;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -14,6 +15,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
+@Profile("!test")
 public class S3FileManager {
 
   private final S3Client s3Client;

--- a/src/main/java/com/komentum/user/controller/DevAuthController.java
+++ b/src/main/java/com/komentum/user/controller/DevAuthController.java
@@ -1,0 +1,49 @@
+package com.komentum.user.controller;
+
+import com.github.javafaker.Faker;
+import com.komentum.auth.JwtUtils;
+import com.komentum.global.security.UserRole;
+import com.komentum.user.domain.Gender;
+import com.komentum.user.domain.User;
+import com.komentum.user.dto.UserAuthResponse;
+import com.komentum.user.repository.UserRepository;
+import com.komentum.user.service.TokenService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile("dev")
+@RequestMapping("/dev")
+@RequiredArgsConstructor
+public class DevAuthController {
+
+  private final UserRepository userRepository;
+  private final TokenService tokenService;
+  private final JwtUtils jwtUtils;
+  private final String testUserEmail = "test@test.com";
+
+  @PostMapping("/users/auth")
+  public ResponseEntity<UserAuthResponse> getTestUserAuth() {
+    User user = userRepository.findByUserEmail(testUserEmail).orElse(null);
+    if (user == null) {
+      Faker faker = new Faker();
+      user = userRepository.save(User.builder()
+          .userEmail(testUserEmail)
+          .role(UserRole.USER)
+          .birth(LocalDate.now().minusYears(10))
+          .gender(Gender.male)
+          .profileImg(faker.internet().image())
+          .introduce(faker.lorem().word())
+          .build());
+    }
+    String accessToken = jwtUtils.generateAccessToken(user.getUserEmail());
+    String refreshToken = jwtUtils.generateRefreshToken(user.getUserEmail());
+    tokenService.saveAccessAndRefreshToken(user.getUserEmail(), accessToken, refreshToken);
+    return ResponseEntity.ok(new UserAuthResponse(accessToken, refreshToken));
+  }
+}

--- a/src/main/java/com/komentum/user/domain/User.java
+++ b/src/main/java/com/komentum/user/domain/User.java
@@ -1,13 +1,17 @@
 package com.komentum.user.domain;
 
+import com.komentum.global.security.UserRole;
 import com.komentum.post.domain.Prefer;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,6 +28,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@Table(name = "\"user\"")
 @EntityListeners(AuditingEntityListener.class)
 public class User {
 
@@ -38,6 +43,9 @@ public class User {
   String profileImg;
   @Column
   String introduce;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, columnDefinition = "varchar(20) default 'USER'")
+  UserRole role;
   @CreatedDate
   LocalDateTime createdAt;
   @LastModifiedDate

--- a/src/main/java/com/komentum/user/dto/KakaoUserInfo.java
+++ b/src/main/java/com/komentum/user/dto/KakaoUserInfo.java
@@ -1,5 +1,6 @@
 package com.komentum.user.dto;
 
+import com.komentum.global.security.UserRole;
 import com.komentum.user.domain.Gender;
 import com.komentum.user.domain.User;
 import java.time.LocalDate;
@@ -25,6 +26,7 @@ public class KakaoUserInfo {
         .profileImg(profileImage)
         .gender(Gender.valueOf(gender))
         .birth(birth)
+        .role(UserRole.USER)
         .build();
   }
 

--- a/src/main/java/com/komentum/user/repository/UserRepository.java
+++ b/src/main/java/com/komentum/user/repository/UserRepository.java
@@ -1,8 +1,10 @@
 package com.komentum.user.repository;
 
 import com.komentum.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, String> {
 
+  Optional<User> findByUserEmail(String userEmail);
 }

--- a/src/test/java/com/komentum/config/EnableTestProfile.java
+++ b/src/test/java/com/komentum/config/EnableTestProfile.java
@@ -1,0 +1,18 @@
+package com.komentum.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@ActiveProfiles("test")
+@Import({GlobalTestMockManager.class})
+public @interface EnableTestProfile {
+
+}

--- a/src/test/java/com/komentum/config/GlobalTestMockManager.java
+++ b/src/test/java/com/komentum/config/GlobalTestMockManager.java
@@ -1,0 +1,17 @@
+package com.komentum.config;
+
+import com.komentum.theme.utils.S3FileManager;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+
+@TestConfiguration
+@Profile("test")
+public class GlobalTestMockManager {
+
+  @Bean
+  public S3FileManager s3FileManager() {
+    return Mockito.mock(S3FileManager.class);
+  }
+}

--- a/src/test/java/com/komentum/controller/TestController.java
+++ b/src/test/java/com/komentum/controller/TestController.java
@@ -1,0 +1,26 @@
+package com.komentum.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+
+  public static String authRequiredPath = "/must/auth";
+
+  @GetMapping("/allow/all")
+  public ResponseEntity<Boolean> publicMethod() {
+    return ResponseEntity.ok(true);
+  }
+
+  @GetMapping("/allow/get")
+  public ResponseEntity<Boolean> privateMethod() {
+    return ResponseEntity.ok(true);
+  }
+
+  @GetMapping("/must/auth")
+  public ResponseEntity<Boolean> mustAuth() {
+    return ResponseEntity.ok(true);
+  }
+}

--- a/src/test/java/com/komentum/global/security/JwtAuthFilterTest.java
+++ b/src/test/java/com/komentum/global/security/JwtAuthFilterTest.java
@@ -1,0 +1,117 @@
+package com.komentum.global.security;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.github.javafaker.Faker;
+import com.komentum.auth.JwtUtils;
+import com.komentum.config.EnableTestProfile;
+import com.komentum.controller.TestController;
+import com.komentum.user.domain.Gender;
+import com.komentum.user.domain.User;
+import com.komentum.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest
+@EnableTestProfile
+@AutoConfigureMockMvc
+class JwtAuthFilterTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private JwtUtils jwtUtils;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private SecurityProperties securityProperties;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    Faker faker = new Faker();
+    User newUser = User.builder()
+        .userEmail(faker.internet().emailAddress())
+        .role(UserRole.USER)
+        .birth(LocalDate.now().minusYears(10))
+        .gender(Gender.male)
+        .profileImg(faker.internet().image())
+        .introduce(faker.lorem().word())
+        .build();
+    user = userRepository.save(newUser);
+  }
+
+  @AfterEach
+  void tearDown() {
+    userRepository.deleteAll();
+  }
+
+  private String getUserAccessToken() {
+    return jwtUtils.generateAccessToken(user.getUserEmail());
+  }
+
+  @Test
+  @DisplayName("success test about permit-all path")
+  void jwtAuthFilter_permitAll_success() throws Exception {
+    // given
+    String whiteListPath = securityProperties.getWhiteList()[0];
+    // when and then
+    RequestBuilder builder = MockMvcRequestBuilders.get(whiteListPath);
+    mockMvc.perform(builder).andExpect(status().isOk()).andDo(print());
+  }
+
+  @Test
+  @DisplayName("success test about permit-get path")
+  void jwtAuthFilter_permitGet_success() throws Exception {
+    // given
+    String whiteListPath = securityProperties.getWhiteListGet()[0];
+    // when
+    RequestBuilder builder = MockMvcRequestBuilders.get(whiteListPath);
+    mockMvc.perform(builder).andExpect(status().isOk()).andDo(print());
+  }
+
+  @Test
+  @DisplayName("success test when token is valid and path requires token")
+  void jwtAuthFilter_whenTokenIsValid_success() throws Exception {
+    // given
+    String token = getUserAccessToken();
+    // when
+    RequestBuilder builder = MockMvcRequestBuilders.get(TestController.authRequiredPath)
+        .header("Authorization", "Bearer " + token);
+    mockMvc.perform(builder).andExpect(status().isOk()).andDo(print());
+  }
+
+  @Test
+  @DisplayName("error test when token doesn't exist but path requires token")
+  void jwtAuthFilter_4xx_noToken() throws Exception {
+    // when and then
+    RequestBuilder builder = MockMvcRequestBuilders.get(TestController.authRequiredPath);
+    mockMvc.perform(builder).andExpect(status().is4xxClientError()).andDo(print());
+  }
+
+  @Test
+  @DisplayName("error test when token isn't valid but path requires token")
+  void jwtAuthFilter_4xx_invalidToken() throws Exception {
+    // given
+    String token = UUID.randomUUID().toString();
+    // when and then
+    RequestBuilder builder = MockMvcRequestBuilders.get(TestController.authRequiredPath)
+        .header("Authorization", "Bearer " + token);
+    mockMvc.perform(builder).andExpect(status().is4xxClientError()).andDo(print());
+  }
+}


### PR DESCRIPTION
# 📌 관련 이슈
- Closes #18 

# 🔍 변경 사항
- JWT 인증 필터 구현
- Spring Security 설정 추가
- Spring Security Filter에 JWT 인증 필터 추가
- 개발 환경(dev)와 다른 환경 분리
  - 테스트 데이터 생성 기능
  - 테스트 계정의 인증 정보 발급 기능
  - swagger 설정

# ✅ 확인 사항
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] gradle 빌드 및 성공 확인
- [x] 설정 파일 서브 모듈 업데이트 완료 (dev/monolithic)

# 추가 확인해야하는 내용 내용
-  swagger는 기본 UI가 제공되므로 application-dev와 application-prod를 별도로 관리하여 기본 UI를 비활성화해야함