### PR TITLE
[ FEAT ] color-style 테이블 구조 개선

### DIFF
--- a/src/main/java/com/komentum/theme/android/dto/AndroidColorDto.java
+++ b/src/main/java/com/komentum/theme/android/dto/AndroidColorDto.java
@@ -20,7 +20,7 @@ public class AndroidColorDto {
     ColorStyle colorStyle = themeStyle.getColorStyle();
     return AndroidColorDto.builder()
         .color(themeStyle.getColor())
-        .attrName(colorStyle.getAndroidStyleName())
+        .attrName(colorStyle.getStylePropsName())
         .build();
   }
 }

--- a/src/main/java/com/komentum/theme/component/controller/ColorStyleController.java
+++ b/src/main/java/com/komentum/theme/component/controller/ColorStyleController.java
@@ -62,9 +62,7 @@ public class ColorStyleController {
             existingColorStyle -> {
               // 필드값만 업데이트
               // 만약 json에 id 값을 추가하면, 바꿀 수 있도록 해야하나? id는 항상 같아야 한다고 생각...
-              existingColorStyle.setExplain(colorStyle.getExplain());
-              existingColorStyle.setIosStyleName(colorStyle.getIosStyleName());
-              existingColorStyle.setAndroidStyleName(colorStyle.getAndroidStyleName());
+              existingColorStyle.update(colorStyle);
               ColorStyle updatedColorStyle = colorStyleRepository.save(existingColorStyle);
               return ResponseEntity.ok(updatedColorStyle);
             })

--- a/src/main/java/com/komentum/theme/component/domain/ColorStyle.java
+++ b/src/main/java/com/komentum/theme/component/domain/ColorStyle.java
@@ -1,7 +1,10 @@
 package com.komentum.theme.component.domain;
 
+import com.komentum.theme.component.enums.Platform;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,9 +30,24 @@ public class ColorStyle {
   @Column(name = "`explain`")
   private String explain;
 
-  @Column(name = "ios_style_name")
-  private String iosStyleName;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Platform platform;
 
-  @Column(name = "android_style_name")
-  private String androidStyleName;
+  @Column(name = "style_sheet_path", nullable = false)
+  private String styleSheetPath;
+
+  @Column(name = "style_element_name", nullable = false)
+  private String styleElementName;
+
+  @Column(name = "style_props_name", nullable = false)
+  private String stylePropsName;
+
+  public void update(ColorStyle colorStyle) {
+    this.explain = colorStyle.explain;
+    this.platform = colorStyle.platform;
+    this.styleSheetPath = colorStyle.styleSheetPath;
+    this.styleElementName = colorStyle.styleElementName;
+    this.stylePropsName = colorStyle.stylePropsName;
+  }
 }

--- a/src/main/java/com/komentum/theme/component/enums/Platform.java
+++ b/src/main/java/com/komentum/theme/component/enums/Platform.java
@@ -1,0 +1,6 @@
+package com.komentum.theme.component.enums;
+
+public enum Platform {
+  ANDROID,
+  IOS;
+}

--- a/src/main/java/com/komentum/theme/theme/dto/ThemeStyleDto.java
+++ b/src/main/java/com/komentum/theme/theme/dto/ThemeStyleDto.java
@@ -13,7 +13,7 @@ public class ThemeStyleDto {
 
   private Integer colorTypeId;
   private String explain;
-  private String iosStyleName;
-  private String androidStyleName;
+  private String styleElementName;
+  private String stylePropsName;
   private String color;
 }

--- a/src/main/java/com/komentum/theme/theme/service/ThemeService.java
+++ b/src/main/java/com/komentum/theme/theme/service/ThemeService.java
@@ -243,8 +243,8 @@ public class ThemeService {
         .map(style -> ThemeStyleDto.builder()
             .colorTypeId(style.getColorStyle().getColorTypeId())
             .explain(style.getColorStyle().getExplain())
-            .iosStyleName(style.getColorStyle().getIosStyleName())
-            .androidStyleName(style.getColorStyle().getAndroidStyleName())
+            .styleElementName(style.getColorStyle().getStyleElementName())
+            .stylePropsName(style.getColorStyle().getStylePropsName())
             .color(style.getColor())
             .build())
         .collect(Collectors.toList());


### PR DESCRIPTION
# 📌 관련 이슈
- close #20 

# 🔍 변경 사항
- color-style 테이블 구조 개선
- color-style 구조 개선으로 인한 오류 수정

# ✅ 확인 사항
- [x] color-style 관련 기능이 정상적으로 동작하는지 테스트 완료
- [x] gradle 빌드 및 성공 확인

# 추가로 필요한 설명
  - 기존에 구상했던 json 기반 역직렬화는 사용하지 않았음 ( 문자열 잘림, 데이터 이해의 어려움 문제 등 )
  - IOS와 안드로이드 모두 색상 정보를 요소명( = selector / 태그)과 속성명(css / xml 속성)으로 구분할 수 있기 때문에 속성과 요소 기반의 color_style을 설계함
    - ` platform ` : 플랫폼(ios / android) 정보 저장. 플랫폼 간 스타일 종류 불일치 문제 및 플랫폼 확장에 대처하기 용이함
    - `style_sheet_path `: 색상 정보 css / xml의 경로
    - `style_element_name `: css의 selector / xml의 태그명
    - `style_props_name `: css/xml의 속성명