### PR TITLE
[#37] user detail 객체에 사용자 이메일 추가

### DIFF
--- a/src/main/java/com/komentum/global/dto/CustomUserDetails.java
+++ b/src/main/java/com/komentum/global/dto/CustomUserDetails.java
@@ -1,9 +1,8 @@
-package com.komentum.global.security;
+package com.komentum.global.dto;
 
-import java.util.ArrayList;
+import com.komentum.global.security.UserRole;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -12,16 +11,19 @@ import org.springframework.security.core.userdetails.UserDetails;
 public class CustomUserDetails implements UserDetails {
 
   private final UserRole userRole;
+  private final String userEmail;
 
   @Builder
-  public CustomUserDetails(UserRole userRole) {
+  public CustomUserDetails(String userEmail, UserRole userRole) {
     this.userRole = userRole;
+    this.userEmail = userEmail;
   }
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    List<String> authorities = new ArrayList<>(List.of(userRole.name()));
-    return authorities.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    return List.of(
+        new SimpleGrantedAuthority(userRole.name())
+    );
   }
 
   @Override
@@ -31,6 +33,6 @@ public class CustomUserDetails implements UserDetails {
 
   @Override
   public String getUsername() {
-    return null;
+    return userEmail;
   }
 }

--- a/src/main/java/com/komentum/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/komentum/global/security/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.komentum.global.security;
 
+import com.komentum.global.dto.CustomUserDetails;
 import com.komentum.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -23,7 +24,8 @@ public class CustomUserDetailsService implements UserDetailsService {
   @Override
   public UserDetails loadUserByUsername(String userEmail) throws UsernameNotFoundException {
     return userRepository.findByUserEmail(userEmail)
-        .map(res -> CustomUserDetails.builder().userRole(res.getRole()).build())
+        .map(
+            res -> CustomUserDetails.builder().userRole(res.getRole()).userEmail(userEmail).build())
         .orElse(null);
   }
 }

--- a/src/main/java/com/komentum/user/controller/DevAuthController.java
+++ b/src/main/java/com/komentum/user/controller/DevAuthController.java
@@ -25,15 +25,14 @@ public class DevAuthController {
   private final UserRepository userRepository;
   private final TokenService tokenService;
   private final JwtUtils jwtUtils;
-  private final String testUserEmail = "test@test.com";
 
   @PostMapping("/users/auth")
   public ResponseEntity<UserAuthResponse> getTestUserAuth() {
-    User user = userRepository.findByUserEmail(testUserEmail).orElse(null);
+    User user = userRepository.findAll().get(0);
     if (user == null) {
       Faker faker = new Faker();
       user = userRepository.save(User.builder()
-          .userEmail(testUserEmail)
+          .userEmail(user.getUserEmail())
           .role(UserRole.USER)
           .birth(LocalDate.now().minusYears(10))
           .gender(Gender.male)

--- a/src/main/java/com/komentum/user/controller/DevAuthController.java
+++ b/src/main/java/com/komentum/user/controller/DevAuthController.java
@@ -32,7 +32,7 @@ public class DevAuthController {
     if (user == null) {
       Faker faker = new Faker();
       user = userRepository.save(User.builder()
-          .userEmail(user.getUserEmail())
+          .userEmail("test@test.com")
           .role(UserRole.USER)
           .birth(LocalDate.now().minusYears(10))
           .gender(Gender.male)


### PR DESCRIPTION
## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용
관련 이슈: #37  <!-- #issue_number -->
- user email을 CustomUserDetails ( 인증 정보 객체 )에 추가
- 개발용 토큰 발급 시 DB에 저장된 테스트용 사용자 정보를 사용하도록 수정
- 이제 인증이 필요한 요청에 한하여 사용자 이메일(식별자)를 @AuthenticationPrincipal로 받아서 쓸 수 있음

## 테스트 결과
<!-- 테스트 결과를 스크린 샷으로 첨부해주세요. -->
- 수동 테스트 코드 ( 현재는 삭제한 상태 )
<img width="517" height="120" alt="스크린샷 2026-01-07 010237" src="https://github.com/user-attachments/assets/776b1b5a-e9ee-4fe4-9b0b-690d2b0dafb0" />  

- 수동 테스트 결과
<img width="519" height="155" alt="스크린샷 2026-01-07 010356" src="https://github.com/user-attachments/assets/d5d1bcab-a561-4be5-9cbe-fcc0a0664bcc" />  


## PR 체크리스트
- [ ] 커밋 메시지가 가이드라인을 따르는가
- [ ] 테스트 코드를 모두 통과하였는가
- [ ] 관련 이슈를 연결하였는가
