### PR TITLE
Feat/#81 카카오 로그인 및 쿠키 기반 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     // spring-security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    // spring oauth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/komentum/KomentumApplication.java
+++ b/src/main/java/com/komentum/KomentumApplication.java
@@ -2,10 +2,12 @@ package com.komentum;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class KomentumApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/komentum/auth/JwtUtils.java
+++ b/src/main/java/com/komentum/auth/JwtUtils.java
@@ -96,11 +96,11 @@ public class JwtUtils {
    */
   public String resolveJwtToken(HttpRequest request) {
     try {
-      String authorization = request.getHeaders().getFirst(AuthProperty.accessTokenHeader);
-      if (authorization == null || !authorization.startsWith(AuthProperty.accessTokenPrefix)) {
+      String authorization = request.getHeaders().getFirst(AuthProperty.ACCESS_TOKEN_HEADER);
+      if (authorization == null || !authorization.startsWith(AuthProperty.ACCESS_TOKEN_PREFIX)) {
         return null;
       }
-      return authorization.substring(AuthProperty.accessTokenPrefix.length());
+      return authorization.substring(AuthProperty.ACCESS_TOKEN_PREFIX.length());
     } catch (Exception e) {
       log.error(e.getMessage());
       return null;
@@ -127,11 +127,11 @@ public class JwtUtils {
   }
 
   private String extractAccessTokenFromHeader(HttpServletRequest request) {
-    String authorization = request.getHeader(AuthProperty.accessTokenHeader);
-    if (authorization == null || !authorization.startsWith(AuthProperty.accessTokenPrefix)) {
+    String authorization = request.getHeader(AuthProperty.ACCESS_TOKEN_HEADER);
+    if (authorization == null || !authorization.startsWith(AuthProperty.ACCESS_TOKEN_PREFIX)) {
       return null;
     }
-    return authorization.substring(AuthProperty.accessTokenPrefix.length());
+    return authorization.substring(AuthProperty.ACCESS_TOKEN_PREFIX.length());
   }
 
   private String extractAccessTokenFromCookie(HttpServletRequest request) {
@@ -140,7 +140,7 @@ public class JwtUtils {
       return null;
     }
     return Arrays.stream(cookies)
-        .filter(c -> c.getName().equals(AuthProperty.accessTokenCookieName))
+        .filter(c -> c.getName().equals(AuthProperty.ACCESS_TOKEN_COOKIE_NAME))
         .map(Cookie::getValue)
         .findFirst()
         .orElse(null);

--- a/src/main/java/com/komentum/auth/JwtUtils.java
+++ b/src/main/java/com/komentum/auth/JwtUtils.java
@@ -1,16 +1,18 @@
 package com.komentum.auth;
 
 import com.komentum.global.properties.AuthProperty;
+import com.komentum.global.properties.JwtProperty;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpRequest;
 import org.springframework.stereotype.Component;
 
@@ -20,10 +22,12 @@ public class JwtUtils {
 
   String identifier = "publicUserId";
   private final Key SECRET_KEY;
+  private final AuthProperty authProperty;
 
-  public JwtUtils(@Value("${jwt.secret}") String secret_key) {
-    byte[] keyBytes = Decoders.BASE64.decode(secret_key);
+  public JwtUtils(JwtProperty jwtProperty, AuthProperty authProperty) {
+    byte[] keyBytes = Decoders.BASE64.decode(jwtProperty.getSecret());
     this.SECRET_KEY = Keys.hmacShaKeyFor(keyBytes);
+    this.authProperty = authProperty;
   }
 
   /**
@@ -46,14 +50,14 @@ public class JwtUtils {
    * generate access token
    */
   public String generateAccessToken(String publicUserId) {
-    return generateToken(publicUserId, AuthProperty.ACCESS_TOKEN_EXPIRES_IN);
+    return generateToken(publicUserId, authProperty.getAccessTokenExpiresIn());
   }
 
   /**
    * generate refresh token
    */
   public String generateRefreshToken(String publicUserId) {
-    return generateToken(publicUserId, AuthProperty.REFRESH_TOKEN_EXPIRES_IN);
+    return generateToken(publicUserId, authProperty.getRefreshTokenExpiresIn());
   }
 
   /**
@@ -92,11 +96,11 @@ public class JwtUtils {
    */
   public String resolveJwtToken(HttpRequest request) {
     try {
-      String authorization = request.getHeaders().getFirst(AuthProperty.ACCESS_TOKEN_HEADER);
-      if (authorization == null || !authorization.startsWith(AuthProperty.ACCESS_TOKEN_PREFIX)) {
+      String authorization = request.getHeaders().getFirst(AuthProperty.accessTokenHeader);
+      if (authorization == null || !authorization.startsWith(AuthProperty.accessTokenPrefix)) {
         return null;
       }
-      return authorization.substring(AuthProperty.ACCESS_TOKEN_PREFIX.length());
+      return authorization.substring(AuthProperty.accessTokenPrefix.length());
     } catch (Exception e) {
       log.error(e.getMessage());
       return null;
@@ -111,14 +115,34 @@ public class JwtUtils {
    */
   public String resolveJwtToken(HttpServletRequest request) {
     try {
-      String authorization = request.getHeader(AuthProperty.ACCESS_TOKEN_HEADER);
-      if (authorization == null || !authorization.startsWith(AuthProperty.ACCESS_TOKEN_PREFIX)) {
-        return null;
+      String accessToken = extractAccessTokenFromHeader(request);
+      if (accessToken == null) {
+        accessToken = extractAccessTokenFromCookie(request);
       }
-      return authorization.substring(AuthProperty.ACCESS_TOKEN_PREFIX.length());
+      return accessToken;
     } catch (Exception e) {
       log.error(e.getMessage());
       return null;
     }
+  }
+
+  private String extractAccessTokenFromHeader(HttpServletRequest request) {
+    String authorization = request.getHeader(AuthProperty.accessTokenHeader);
+    if (authorization == null || !authorization.startsWith(AuthProperty.accessTokenPrefix)) {
+      return null;
+    }
+    return authorization.substring(AuthProperty.accessTokenPrefix.length());
+  }
+
+  private String extractAccessTokenFromCookie(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return null;
+    }
+    return Arrays.stream(cookies)
+        .filter(c -> c.getName().equals(AuthProperty.accessTokenCookieName))
+        .map(Cookie::getValue)
+        .findFirst()
+        .orElse(null);
   }
 }

--- a/src/main/java/com/komentum/config/SwaggerConfig.java
+++ b/src/main/java/com/komentum/config/SwaggerConfig.java
@@ -8,13 +8,17 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
 @Profile("dev")
+@RequiredArgsConstructor
 public class SwaggerConfig {
+
+  private final AuthProperty authProperty;
 
   @Bean
   public OpenAPI openAPI() {
@@ -41,8 +45,8 @@ public class SwaggerConfig {
             new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .in(SecurityScheme.In.HEADER)
-                .scheme(AuthProperty.ACCESS_TOKEN_PREFIX)
-                .name(AuthProperty.ACCESS_TOKEN_HEADER)
+                .scheme(AuthProperty.accessTokenPrefix)
+                .name(AuthProperty.accessTokenHeader)
                 .bearerFormat("JWT"));
   }
 

--- a/src/main/java/com/komentum/config/SwaggerConfig.java
+++ b/src/main/java/com/komentum/config/SwaggerConfig.java
@@ -45,8 +45,8 @@ public class SwaggerConfig {
             new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .in(SecurityScheme.In.HEADER)
-                .scheme(AuthProperty.accessTokenPrefix)
-                .name(AuthProperty.accessTokenHeader)
+                .scheme(AuthProperty.ACCESS_TOKEN_PREFIX)
+                .name(AuthProperty.ACCESS_TOKEN_HEADER)
                 .bearerFormat("JWT"));
   }
 

--- a/src/main/java/com/komentum/global/dto/CustomOAuth2User.java
+++ b/src/main/java/com/komentum/global/dto/CustomOAuth2User.java
@@ -1,0 +1,36 @@
+package com.komentum.global.dto;
+
+import com.komentum.user.domain.User;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+  private final User user;
+  private final Map<String, Object> attributes;
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(new SimpleGrantedAuthority(user.getRole().getAuthority()));
+  }
+
+  @Override
+  public String getName() {
+    return user.getPublicUserId();
+  }
+
+  public String getUserIdentifier() {
+    return user.getPublicUserId();
+  }
+}

--- a/src/main/java/com/komentum/global/dto/CustomUserDetails.java
+++ b/src/main/java/com/komentum/global/dto/CustomUserDetails.java
@@ -27,7 +27,7 @@ public class CustomUserDetails implements UserDetails {
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
     return List.of(
-        new SimpleGrantedAuthority(userRole.name())
+        new SimpleGrantedAuthority(userRole.getAuthority())
     );
   }
 

--- a/src/main/java/com/komentum/global/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/komentum/global/dto/OAuth2UserInfo.java
@@ -1,0 +1,53 @@
+package com.komentum.global.dto;
+
+import com.komentum.global.security.UserRole;
+import com.komentum.user.domain.AuthProvider;
+import com.komentum.user.domain.User;
+import java.util.Map;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OAuth2UserInfo {
+
+  private String userEmail;
+  private String profileImageUrl;
+  private String name;
+  private AuthProvider authProvider;
+
+  public User toEntity() {
+    return User.builder()
+        .userEmail(this.userEmail)
+        .profileImg(profileImageUrl)
+        .authProvider(authProvider)
+        .name(name)
+        .role(UserRole.USER)
+        .publicUserId(UUID.randomUUID().toString())
+        .build();
+  }
+
+  public static OAuth2UserInfo of(String registrationId, Map<String, Object> attributes) {
+    AuthProvider provider = AuthProvider.from(registrationId);
+    return switch (provider) {
+      case KAKAO -> ofKakao(attributes, provider);
+      case LOCAL -> throw new IllegalArgumentException("invalid oauth2 provider");
+    };
+  }
+
+  private static OAuth2UserInfo ofKakao(Map<String, Object> attributes, AuthProvider authProvider) {
+    Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+    Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+    return OAuth2UserInfo.builder()
+        .name((String) profile.get("nickname"))
+        .userEmail((String) account.get("email"))
+        .profileImageUrl((String) profile.get("profile_image_url"))
+        .authProvider(authProvider)
+        .build();
+  }
+}

--- a/src/main/java/com/komentum/global/properties/AuthProperty.java
+++ b/src/main/java/com/komentum/global/properties/AuthProperty.java
@@ -9,10 +9,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "auth")
 public class AuthProperty {
 
-  public static final String accessTokenPrefix = "Bearer";
-  public static final String accessTokenHeader = "Authorization";
-  public static final String accessTokenCookieName = "access_token";
-  public static final String refreshTokenCookieName = "refresh_token";
+  // 인증 관련 상수
+  public static final String ACCESS_TOKEN_PREFIX = "Bearer";
+  public static final String ACCESS_TOKEN_HEADER = "Authorization";
+  public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+  public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+  // 인증 관련 환경 변수
   private final Long accessTokenExpiresIn;
   private final Long refreshTokenExpiresIn;
   private final String oauth2RedirectUrl;

--- a/src/main/java/com/komentum/global/properties/AuthProperty.java
+++ b/src/main/java/com/komentum/global/properties/AuthProperty.java
@@ -1,9 +1,20 @@
 package com.komentum.global.properties;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "auth")
 public class AuthProperty {
 
-  public static final String ACCESS_TOKEN_PREFIX = "Bearer";
-  public static final String ACCESS_TOKEN_HEADER = "Authorization";
-  public static final Long ACCESS_TOKEN_EXPIRES_IN = 360000L;
-  public static final Long REFRESH_TOKEN_EXPIRES_IN = 360000L;
+  public static final String accessTokenPrefix = "Bearer";
+  public static final String accessTokenHeader = "Authorization";
+  public static final String accessTokenCookieName = "access_token";
+  public static final String refreshTokenCookieName = "refresh_token";
+  private final Long accessTokenExpiresIn;
+  private final Long refreshTokenExpiresIn;
+  private final String oauth2RedirectUrl;
+  private final Boolean withHttps;
 }

--- a/src/main/java/com/komentum/global/properties/JwtProperty.java
+++ b/src/main/java/com/komentum/global/properties/JwtProperty.java
@@ -1,0 +1,13 @@
+package com.komentum.global.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperty {
+
+  private final String secret;
+}

--- a/src/main/java/com/komentum/global/security/CustomOauth2UserService.java
+++ b/src/main/java/com/komentum/global/security/CustomOauth2UserService.java
@@ -1,0 +1,47 @@
+package com.komentum.global.security;
+
+import com.komentum.global.dto.CustomOAuth2User;
+import com.komentum.global.dto.OAuth2UserInfo;
+import com.komentum.user.domain.User;
+import com.komentum.user.repository.UserRepository;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOauth2UserService extends DefaultOAuth2UserService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  @Transactional
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    Map<String, Object> attributes = super.loadUser(userRequest).getAttributes();
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.of(registrationId, attributes);
+    User serviceUser = createOrRetriveUser(oAuth2UserInfo);
+    return new CustomOAuth2User(serviceUser, attributes);
+  }
+
+  @Transactional
+  public User createOrRetriveUser(OAuth2UserInfo oAuth2UserInfo) {
+    User serviceUser = userRepository.findByUserEmail(oAuth2UserInfo.getUserEmail()).orElse(null);
+    if (serviceUser == null) {
+      try {
+        serviceUser = userRepository.save(oAuth2UserInfo.toEntity());
+      } catch (DataIntegrityViolationException e) {
+        // 동시성 문제 대응 : 이미 insert 되었다면 DB의 사용자 사용
+        serviceUser = userRepository.findByUserEmail(oAuth2UserInfo.getUserEmail())
+            .orElseThrow(() -> e);
+      }
+    }
+    return serviceUser;
+  }
+}

--- a/src/main/java/com/komentum/global/security/CustomOauth2UserService.java
+++ b/src/main/java/com/komentum/global/security/CustomOauth2UserService.java
@@ -26,12 +26,12 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
     Map<String, Object> attributes = super.loadUser(userRequest).getAttributes();
     String registrationId = userRequest.getClientRegistration().getRegistrationId();
     OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.of(registrationId, attributes);
-    User serviceUser = createOrRetriveUser(oAuth2UserInfo);
+    User serviceUser = createOrRetrieveUser(oAuth2UserInfo);
     return new CustomOAuth2User(serviceUser, attributes);
   }
 
   @Transactional
-  public User createOrRetriveUser(OAuth2UserInfo oAuth2UserInfo) {
+  public User createOrRetrieveUser(OAuth2UserInfo oAuth2UserInfo) {
     User serviceUser = userRepository.findByUserEmail(oAuth2UserInfo.getUserEmail()).orElse(null);
     if (serviceUser == null) {
       try {

--- a/src/main/java/com/komentum/global/security/OAuth2LogInSuccessHandler.java
+++ b/src/main/java/com/komentum/global/security/OAuth2LogInSuccessHandler.java
@@ -3,12 +3,12 @@ package com.komentum.global.security;
 import com.komentum.auth.JwtUtils;
 import com.komentum.global.dto.CustomOAuth2User;
 import com.komentum.global.properties.AuthProperty;
+import com.komentum.global.security.cookie.TokenCookieManager;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -19,6 +19,7 @@ public class OAuth2LogInSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
   private final JwtUtils jwtUtils;
   private final AuthProperty authProperty;
+  private final TokenCookieManager tokenCookieManager;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -27,24 +28,7 @@ public class OAuth2LogInSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     String accessToken = jwtUtils.generateAccessToken(oAuth2User.getUserIdentifier());
     String refreshToken = jwtUtils.generateRefreshToken(oAuth2User.getUserIdentifier());
-    ResponseCookie accessTokenCookie = ResponseCookie
-        .from(AuthProperty.accessTokenCookieName, accessToken)
-        .httpOnly(true)
-        .secure(authProperty.getWithHttps())
-        .path("/")
-        .maxAge(authProperty.getAccessTokenExpiresIn())
-        .sameSite("Strict")
-        .build();
-    ResponseCookie refreshTokenCookie = ResponseCookie
-        .from(AuthProperty.refreshTokenCookieName, refreshToken)
-        .httpOnly(true)
-        .secure(authProperty.getWithHttps())
-        .path("/")
-        .maxAge(authProperty.getRefreshTokenExpiresIn())
-        .sameSite("Strict")
-        .build();
-    response.addHeader("Set-Cookie", accessTokenCookie.toString());
-    response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+    tokenCookieManager.addTokenOnCookie(response, accessToken, refreshToken);
 
     String redirectUrl = authProperty.getOauth2RedirectUrl();
     response.sendRedirect(redirectUrl);

--- a/src/main/java/com/komentum/global/security/OAuth2LogInSuccessHandler.java
+++ b/src/main/java/com/komentum/global/security/OAuth2LogInSuccessHandler.java
@@ -1,0 +1,52 @@
+package com.komentum.global.security;
+
+import com.komentum.auth.JwtUtils;
+import com.komentum.global.dto.CustomOAuth2User;
+import com.komentum.global.properties.AuthProperty;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LogInSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+  private final JwtUtils jwtUtils;
+  private final AuthProperty authProperty;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException, ServletException {
+    CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+    String accessToken = jwtUtils.generateAccessToken(oAuth2User.getUserIdentifier());
+    String refreshToken = jwtUtils.generateRefreshToken(oAuth2User.getUserIdentifier());
+    ResponseCookie accessTokenCookie = ResponseCookie
+        .from(AuthProperty.accessTokenCookieName, accessToken)
+        .httpOnly(true)
+        .secure(authProperty.getWithHttps())
+        .path("/")
+        .maxAge(authProperty.getAccessTokenExpiresIn())
+        .sameSite("Strict")
+        .build();
+    ResponseCookie refreshTokenCookie = ResponseCookie
+        .from(AuthProperty.refreshTokenCookieName, refreshToken)
+        .httpOnly(true)
+        .secure(authProperty.getWithHttps())
+        .path("/")
+        .maxAge(authProperty.getRefreshTokenExpiresIn())
+        .sameSite("Strict")
+        .build();
+    response.addHeader("Set-Cookie", accessTokenCookie.toString());
+    response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
+    String redirectUrl = authProperty.getOauth2RedirectUrl();
+    response.sendRedirect(redirectUrl);
+  }
+}

--- a/src/main/java/com/komentum/global/security/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/komentum/global/security/OAuth2LoginFailureHandler.java
@@ -1,0 +1,29 @@
+package com.komentum.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.entity.ContentType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException {
+    log.info("소셜 로그인 실패", exception);
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType(ContentType.APPLICATION_JSON.getMimeType());
+    response.getWriter().write("""
+        {
+          "error": "OAUTH2_LOGIN_FAILED",
+          "message": "소셜 로그인 실패"
+        }
+        """);
+  }
+}

--- a/src/main/java/com/komentum/global/security/SecurityConfig.java
+++ b/src/main/java/com/komentum/global/security/SecurityConfig.java
@@ -32,6 +32,12 @@ public class SecurityConfig {
 
   private final FileStorageProperty fileStorageProperty;
 
+  private final CustomOauth2UserService customOauth2UserService;
+
+  private final OAuth2LogInSuccessHandler oAuth2LogInSuccessHandler;
+
+  private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
@@ -39,6 +45,7 @@ public class SecurityConfig {
         .cors(Customizer.withDefaults())
         .formLogin(AbstractHttpConfigurer::disable)
         .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+        // 요청 인증 / 인가 설정
         .authorizeHttpRequests(auth -> {
           auth.requestMatchers(securityProperties.getWhiteList()).permitAll();
           auth.requestMatchers(HttpMethod.GET, securityProperties.getWhiteListGet()).permitAll();
@@ -49,6 +56,13 @@ public class SecurityConfig {
             auth.requestMatchers(HttpMethod.GET, WebConfig.UPLOAD_URL_PREFIX + "/**").permitAll();
           }
           auth.anyRequest().authenticated();
+        })
+        // oauth2 설정
+        .oauth2Login(oauth -> {
+          oauth.userInfoEndpoint(c -> c
+                  .userService(customOauth2UserService))
+              .successHandler(oAuth2LogInSuccessHandler)
+              .failureHandler(oAuth2LoginFailureHandler);
         });
     return http.build();
   }

--- a/src/main/java/com/komentum/global/security/SecurityConfig.java
+++ b/src/main/java/com/komentum/global/security/SecurityConfig.java
@@ -70,7 +70,10 @@ public class SecurityConfig {
                   .userService(customOauth2UserService))
               .successHandler(oAuth2LogInSuccessHandler)
               .failureHandler(oAuth2LoginFailureHandler);
-        });
+        })
+        .exceptionHandling(exception -> exception.authenticationEntryPoint(
+            new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)
+        ));
     return http.build();
   }
 

--- a/src/main/java/com/komentum/global/security/SecurityConfig.java
+++ b/src/main/java/com/komentum/global/security/SecurityConfig.java
@@ -12,11 +12,14 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -47,6 +50,8 @@ public class SecurityConfig {
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .formLogin(AbstractHttpConfigurer::disable)
         .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+        .sessionManagement(session ->
+            session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         // 요청 인증 / 인가 설정
         .authorizeHttpRequests(auth -> {
           auth.requestMatchers(securityProperties.getWhiteList()).permitAll();

--- a/src/main/java/com/komentum/global/security/UserRole.java
+++ b/src/main/java/com/komentum/global/security/UserRole.java
@@ -4,4 +4,8 @@ public enum UserRole {
   GUEST,
   USER,
   ADMIN;
+
+  public String getAuthority() {
+    return "ROLE_" + name();
+  }
 }

--- a/src/main/java/com/komentum/global/security/cookie/TokenCookieManager.java
+++ b/src/main/java/com/komentum/global/security/cookie/TokenCookieManager.java
@@ -15,7 +15,7 @@ public class TokenCookieManager {
 
   private ResponseCookie generateAccessTokenCookie(String accessToken, Long maxAge) {
     return ResponseCookie
-        .from(AuthProperty.accessTokenCookieName, accessToken)
+        .from(AuthProperty.ACCESS_TOKEN_COOKIE_NAME, accessToken)
         .httpOnly(true)
         .secure(authProperty.getWithHttps())
         .path("/")
@@ -26,7 +26,7 @@ public class TokenCookieManager {
 
   private ResponseCookie generateRefreshTokenCookie(String refreshToken, Long maxAge) {
     return ResponseCookie
-        .from(AuthProperty.refreshTokenCookieName, refreshToken)
+        .from(AuthProperty.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
         .httpOnly(true)
         .secure(authProperty.getWithHttps())
         .path("/")

--- a/src/main/java/com/komentum/global/security/cookie/TokenCookieManager.java
+++ b/src/main/java/com/komentum/global/security/cookie/TokenCookieManager.java
@@ -1,0 +1,61 @@
+package com.komentum.global.security.cookie;
+
+import com.komentum.global.properties.AuthProperty;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TokenCookieManager {
+
+  private final AuthProperty authProperty;
+
+  private ResponseCookie generateAccessTokenCookie(String accessToken, Long maxAge) {
+    return ResponseCookie
+        .from(AuthProperty.accessTokenCookieName, accessToken)
+        .httpOnly(true)
+        .secure(authProperty.getWithHttps())
+        .path("/")
+        .maxAge(maxAge)
+        .sameSite("Strict")
+        .build();
+  }
+
+  private ResponseCookie generateRefreshTokenCookie(String refreshToken, Long maxAge) {
+    return ResponseCookie
+        .from(AuthProperty.refreshTokenCookieName, refreshToken)
+        .httpOnly(true)
+        .secure(authProperty.getWithHttps())
+        .path("/")
+        .maxAge(maxAge)
+        .sameSite("Strict")
+        .build();
+  }
+
+  /**
+   * 로그인 시 쿠키에 토큰을 추가한다
+   * */
+  public void addTokenOnCookie(
+      HttpServletResponse response,
+      String accessToken,
+      String refreshToken
+  ) {
+    ResponseCookie accessTokenCookie = generateAccessTokenCookie(accessToken,
+        authProperty.getAccessTokenExpiresIn());
+    ResponseCookie refreshTokenCookie = generateRefreshTokenCookie(refreshToken,
+        authProperty.getRefreshTokenExpiresIn());
+    response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+    response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+  }
+
+  /**
+   * 로그아웃 시 쿠키에서 토큰을 제거한다
+   * */
+  public void removeTokenOnCookie(HttpServletResponse response) {
+    response.addHeader(HttpHeaders.SET_COOKIE, generateAccessTokenCookie("", 0L).toString());
+    response.addHeader(HttpHeaders.SET_COOKIE, generateRefreshTokenCookie("", 0L).toString());
+  }
+}

--- a/src/main/java/com/komentum/user/client/KakaoAuthHttpClient.java
+++ b/src/main/java/com/komentum/user/client/KakaoAuthHttpClient.java
@@ -26,9 +26,9 @@ public class KakaoAuthHttpClient {
   private final String redirectUri;
 
   public KakaoAuthHttpClient(
-      @Value("${auth.kakao.client-id}") String clientId,
-      @Value("${auth.kakao.client-secret}") String clientSecret,
-      @Value("${auth.kakao.redirect-uri}") String redirectUri
+      @Value("${spring.security.oauth2.client.registration.kakao.client-id}") String clientId,
+      @Value("${spring.security.oauth2.client.registration.kakao.client-secret}") String clientSecret,
+      @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}") String redirectUri
   ) {
     this.clientId = clientId;
     this.clientSecret = clientSecret;

--- a/src/main/java/com/komentum/user/controller/DevAuthController.java
+++ b/src/main/java/com/komentum/user/controller/DevAuthController.java
@@ -1,11 +1,13 @@
 package com.komentum.user.controller;
 
 import com.komentum.auth.JwtUtils;
+import com.komentum.global.security.cookie.TokenCookieManager;
 import com.komentum.seed.seeder.UserSeeder;
 import com.komentum.user.domain.User;
 import com.komentum.user.dto.UserAuthResponse;
 import com.komentum.user.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
@@ -22,14 +24,16 @@ public class DevAuthController {
   private final UserSeeder userSeeder;
   private final TokenService tokenService;
   private final JwtUtils jwtUtils;
+  private final TokenCookieManager tokenCookieManager;
 
   @PostMapping("/users/auth")
   @Operation(summary = "DB의 무작위 사용자를 기반으로 access token과 refresh token 발급")
-  public ResponseEntity<UserAuthResponse> getTestUserAuth() {
+  public ResponseEntity<UserAuthResponse> getTestUserAuth(HttpServletResponse response) {
     User user = userSeeder.createOrRetrieveRootUser();
     String accessToken = jwtUtils.generateAccessToken(user.getPublicUserId());
     String refreshToken = jwtUtils.generateRefreshToken(user.getPublicUserId());
     tokenService.saveAccessAndRefreshToken(user.getUserEmail(), accessToken, refreshToken);
+    tokenCookieManager.addTokenOnCookie(response, accessToken, refreshToken);
     return ResponseEntity.ok(new UserAuthResponse(accessToken, refreshToken));
   }
 }

--- a/src/main/java/com/komentum/user/controller/UserAuthController.java
+++ b/src/main/java/com/komentum/user/controller/UserAuthController.java
@@ -49,14 +49,6 @@ public class UserAuthController {
     return ResponseEntity.ok(userAuthService.processLocalSignIn(localLoginRequestDto));
   }
 
-//  @PostMapping("/kakao/logout")
-//  public ResponseEntity<String> logoutWithKakao(
-//      @RequestHeader(AuthProperty.accessTokenHeader) String accessToken) {
-//    accessToken = accessToken.replace(AuthProperty.accessTokenPrefix, "");
-//    userAuthService.handleLogout(accessToken);
-//    return ResponseEntity.ok("logout success");
-//  }
-
   // 로컬 로그아웃 기능
   @PostMapping("/local/sign-out")
   @Operation(summary = "인증된 사용자가 로그아웃을 진행한다")
@@ -74,8 +66,8 @@ public class UserAuthController {
   @PostMapping("/token")
   @Operation(summary = "인증된 사용자의 refresh token으로 토큰을 재발급한다")
   public ResponseEntity<UserAuthResponse> generateToken(
-      @RequestHeader(AuthProperty.accessTokenHeader) String refreshToken) {
-    refreshToken = refreshToken.replace(AuthProperty.accessTokenPrefix, "");
+      @RequestHeader(AuthProperty.ACCESS_TOKEN_HEADER) String refreshToken) {
+    refreshToken = refreshToken.replace(AuthProperty.ACCESS_TOKEN_PREFIX, "");
     return ResponseEntity.ok(userAuthService.doRefreshTokenRotation(refreshToken));
   }
 }

--- a/src/main/java/com/komentum/user/controller/UserAuthController.java
+++ b/src/main/java/com/komentum/user/controller/UserAuthController.java
@@ -46,7 +46,7 @@ public class UserAuthController {
     UserAuthResponse userAuthResponse = userAuthService.processLocalSignIn(localLoginRequestDto);
     tokenCookieManager.addTokenOnCookie(response, userAuthResponse.getAccessToken(),
         userAuthResponse.getRefreshToken());
-    return ResponseEntity.ok(userAuthService.processLocalSignIn(localLoginRequestDto));
+    return ResponseEntity.ok(userAuthResponse);
   }
 
   // 로컬 로그아웃 기능

--- a/src/main/java/com/komentum/user/controller/UserAuthController.java
+++ b/src/main/java/com/komentum/user/controller/UserAuthController.java
@@ -1,11 +1,16 @@
 package com.komentum.user.controller;
 
+import com.komentum.auth.JwtUtils;
 import com.komentum.global.properties.AuthProperty;
+import com.komentum.global.security.cookie.TokenCookieManager;
 import com.komentum.user.dto.LocalLoginRequestDto;
 import com.komentum.user.dto.SignUpRequestDto;
 import com.komentum.user.dto.UserAuthResponse;
 import com.komentum.user.service.UserAuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,15 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class UserAuthController {
 
   private final UserAuthService userAuthService;
-  private final AuthProperty authProperty;
-
-  public UserAuthController(UserAuthService userAuthService, AuthProperty authProperty) {
-    this.userAuthService = userAuthService;
-    this.authProperty = authProperty;
-  }
+  private final TokenCookieManager tokenCookieManager;
+  private final JwtUtils jwtUtils;
 
 
   // Local 회원가입 기능
@@ -39,28 +41,29 @@ public class UserAuthController {
   @PostMapping("/local/sign-in")
   @Operation(summary = "인증되지 않은 사용자가 로컬 로그인을 진행한다")
   public ResponseEntity<UserAuthResponse> signInLocal(
-      @RequestBody LocalLoginRequestDto localLoginRequestDto) {
+      @RequestBody LocalLoginRequestDto localLoginRequestDto,
+      HttpServletResponse response) {
+    UserAuthResponse userAuthResponse = userAuthService.processLocalSignIn(localLoginRequestDto);
+    tokenCookieManager.addTokenOnCookie(response, userAuthResponse.getAccessToken(),
+        userAuthResponse.getRefreshToken());
     return ResponseEntity.ok(userAuthService.processLocalSignIn(localLoginRequestDto));
   }
 
-  /**
-   * 카카오 로그아웃 기능
-   */
-  @PostMapping("/kakao/logout")
-  public ResponseEntity<String> logoutWithKakao(
-      @RequestHeader(AuthProperty.accessTokenHeader) String accessToken) {
-    accessToken = accessToken.replace(AuthProperty.accessTokenPrefix, "");
-    userAuthService.handleLogout(accessToken);
-    return ResponseEntity.ok("logout success");
-  }
+//  @PostMapping("/kakao/logout")
+//  public ResponseEntity<String> logoutWithKakao(
+//      @RequestHeader(AuthProperty.accessTokenHeader) String accessToken) {
+//    accessToken = accessToken.replace(AuthProperty.accessTokenPrefix, "");
+//    userAuthService.handleLogout(accessToken);
+//    return ResponseEntity.ok("logout success");
+//  }
 
   // 로컬 로그아웃 기능
   @PostMapping("/local/sign-out")
-  @Operation(summary = "인증된 사용자가 로컬 로그아웃을 진행한다")
-  public ResponseEntity<String> signOutLocal(
-      @RequestHeader(AuthProperty.accessTokenHeader) String accessToken) {
-    accessToken = accessToken.replace(AuthProperty.accessTokenPrefix, "");
+  @Operation(summary = "인증된 사용자가 로그아웃을 진행한다")
+  public ResponseEntity<String> signOut(HttpServletRequest request, HttpServletResponse response) {
+    String accessToken = jwtUtils.resolveJwtToken(request);
     userAuthService.handleLogout(accessToken);
+    tokenCookieManager.removeTokenOnCookie(response);
     return ResponseEntity.ok("logout success");
   }
 

--- a/src/main/java/com/komentum/user/controller/UserAuthController.java
+++ b/src/main/java/com/komentum/user/controller/UserAuthController.java
@@ -18,9 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserAuthController {
 
   private final UserAuthService userAuthService;
+  private final AuthProperty authProperty;
 
-  public UserAuthController(UserAuthService userAuthService) {
+  public UserAuthController(UserAuthService userAuthService, AuthProperty authProperty) {
     this.userAuthService = userAuthService;
+    this.authProperty = authProperty;
   }
 
 
@@ -46,8 +48,8 @@ public class UserAuthController {
    */
   @PostMapping("/kakao/logout")
   public ResponseEntity<String> logoutWithKakao(
-      @RequestHeader(AuthProperty.ACCESS_TOKEN_HEADER) String accessToken) {
-    accessToken = accessToken.replace(AuthProperty.ACCESS_TOKEN_PREFIX, "");
+      @RequestHeader(AuthProperty.accessTokenHeader) String accessToken) {
+    accessToken = accessToken.replace(AuthProperty.accessTokenPrefix, "");
     userAuthService.handleLogout(accessToken);
     return ResponseEntity.ok("logout success");
   }
@@ -56,8 +58,8 @@ public class UserAuthController {
   @PostMapping("/local/sign-out")
   @Operation(summary = "인증된 사용자가 로컬 로그아웃을 진행한다")
   public ResponseEntity<String> signOutLocal(
-      @RequestHeader(AuthProperty.ACCESS_TOKEN_HEADER) String accessToken) {
-    accessToken = accessToken.replace(AuthProperty.ACCESS_TOKEN_PREFIX, "");
+      @RequestHeader(AuthProperty.accessTokenHeader) String accessToken) {
+    accessToken = accessToken.replace(AuthProperty.accessTokenPrefix, "");
     userAuthService.handleLogout(accessToken);
     return ResponseEntity.ok("logout success");
   }
@@ -69,8 +71,8 @@ public class UserAuthController {
   @PostMapping("/token")
   @Operation(summary = "인증된 사용자의 refresh token으로 토큰을 재발급한다")
   public ResponseEntity<UserAuthResponse> generateToken(
-      @RequestHeader(AuthProperty.ACCESS_TOKEN_HEADER) String refreshToken) {
-    refreshToken = refreshToken.replace(AuthProperty.ACCESS_TOKEN_PREFIX, "");
+      @RequestHeader(AuthProperty.accessTokenHeader) String refreshToken) {
+    refreshToken = refreshToken.replace(AuthProperty.accessTokenPrefix, "");
     return ResponseEntity.ok(userAuthService.doRefreshTokenRotation(refreshToken));
   }
 }

--- a/src/main/java/com/komentum/user/domain/AuthProvider.java
+++ b/src/main/java/com/komentum/user/domain/AuthProvider.java
@@ -1,0 +1,21 @@
+package com.komentum.user.domain;
+
+import java.util.Arrays;
+
+public enum AuthProvider {
+  LOCAL("local"),
+  KAKAO("kakao");
+
+  private final String registrationId;
+
+  AuthProvider(String registrationId) {
+    this.registrationId = registrationId;
+  }
+
+  public static AuthProvider from(String registrationId) {
+    return Arrays.stream(values())
+        .filter(platform -> platform.registrationId.equals(registrationId))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Unsupported oauth2 provider"));
+  }
+}

--- a/src/main/java/com/komentum/user/domain/User.java
+++ b/src/main/java/com/komentum/user/domain/User.java
@@ -15,7 +15,6 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -35,10 +34,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class User {
 
   @Id
-  @GeneratedValue (strategy = GenerationType.IDENTITY)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(unique = true, nullable = false, updatable = false)
   Long userId;
-  @Column (unique = true, nullable = false, updatable = false)
+  @Column(unique = true, nullable = false, updatable = false)
   String publicUserId;
   @Column(unique = true, nullable = false)
   String userEmail;
@@ -58,12 +57,16 @@ public class User {
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, columnDefinition = "varchar(20) default 'USER'")
   UserRole role;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, columnDefinition = "varchar(20) default 'LOCAL'")
+  @Builder.Default
+  AuthProvider authProvider = AuthProvider.LOCAL;
   @CreatedDate
   LocalDateTime createdAt;
   @LastModifiedDate
   LocalDateTime updatedAt;
 
-  public boolean matchPassword(String rawPassword,  PasswordEncoder passwordEncoder){
+  public boolean matchPassword(String rawPassword, PasswordEncoder passwordEncoder) {
     return passwordEncoder.matches(rawPassword, this.encryptedPassword);
   }
 }

--- a/src/main/java/com/komentum/user/service/TokenService.java
+++ b/src/main/java/com/komentum/user/service/TokenService.java
@@ -8,9 +8,13 @@ import org.springframework.stereotype.Service;
 public class TokenService {
 
   private final RedisSingleDataService redisSingleDataService;
+  private final AuthProperty authProperty;
 
-  public TokenService(RedisSingleDataService redisSingleDataService) {
+  public TokenService(
+      RedisSingleDataService redisSingleDataService,
+      AuthProperty authProperty) {
     this.redisSingleDataService = redisSingleDataService;
+    this.authProperty = authProperty;
   }
 
   public String getAccessTokenKey(String email) {
@@ -23,12 +27,12 @@ public class TokenService {
 
   public boolean saveAccessToken(String email, String accessToken) {
     return redisSingleDataService.set(getAccessTokenKey(email), accessToken,
-        AuthProperty.ACCESS_TOKEN_EXPIRES_IN.intValue());
+        authProperty.getAccessTokenExpiresIn().intValue());
   }
 
   public boolean saveRefreshToken(String email, String refreshToken) {
     return redisSingleDataService.set(getRefreshTokenKey(email), refreshToken,
-        AuthProperty.REFRESH_TOKEN_EXPIRES_IN.intValue());
+        authProperty.getRefreshTokenExpiresIn().intValue());
   }
 
   public boolean saveAccessAndRefreshToken(String email, String accessToken, String refreshToken) {

--- a/src/main/java/com/komentum/user/service/UserAuthService.java
+++ b/src/main/java/com/komentum/user/service/UserAuthService.java
@@ -117,7 +117,7 @@ public class UserAuthService {
    * 로그아웃
    */
   @Transactional
-  public void handleLogout(@RequestHeader(AuthProperty.accessTokenHeader) String accessToken) {
+  public void handleLogout(@RequestHeader(AuthProperty.ACCESS_TOKEN_HEADER) String accessToken) {
     if (accessToken == null || !jwtUtils.validateToken(accessToken)) {
       throw new RuntimeException("Invalid access token");
     }

--- a/src/main/java/com/komentum/user/service/UserAuthService.java
+++ b/src/main/java/com/komentum/user/service/UserAuthService.java
@@ -117,7 +117,7 @@ public class UserAuthService {
    * 로그아웃
    */
   @Transactional
-  public void handleLogout(@RequestHeader(AuthProperty.ACCESS_TOKEN_HEADER) String accessToken) {
+  public void handleLogout(@RequestHeader(AuthProperty.accessTokenHeader) String accessToken) {
     if (accessToken == null || !jwtUtils.validateToken(accessToken)) {
       throw new RuntimeException("Invalid access token");
     }

--- a/src/test/java/com/komentum/global/security/CustomOauth2UserServiceTest.java
+++ b/src/test/java/com/komentum/global/security/CustomOauth2UserServiceTest.java
@@ -1,0 +1,96 @@
+package com.komentum.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.komentum.global.dto.OAuth2UserInfo;
+import com.komentum.user.domain.User;
+import com.komentum.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOauth2UserServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private OAuth2UserInfo oauth2UserInfo;
+
+  @InjectMocks
+  private CustomOauth2UserService customOauth2UserService;
+
+  String userEmail = "testUser@test.com";
+
+  @BeforeEach
+  void setUp() {
+    given(oauth2UserInfo.getUserEmail())
+        .willReturn(userEmail);
+  }
+
+  @Test
+  @DisplayName("if user exists in DB, return that user")
+  void createOrRetrieveUser_whenUserExists() {
+    // given
+    User user = User.builder().build();
+    given(userRepository.findByUserEmail(userEmail))
+        .willReturn(Optional.of(user));
+    // when
+    User res = customOauth2UserService.createOrRetrieveUser(oauth2UserInfo);
+    // then
+    assertThat(res).isEqualTo(user);
+    verify(userRepository, times(1)).findByUserEmail(userEmail);
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("if user not exists in DB, save user and return saved user")
+  void createOrRetrieveUser_whenUserNotExists() {
+    // given
+    User user = User.builder().build();
+    given(oauth2UserInfo.toEntity())
+        .willReturn(user);
+    given(userRepository.findByUserEmail(userEmail))
+        .willReturn(Optional.empty());
+    given(userRepository.save(user))
+        .willReturn(user);
+    // when
+    User res = customOauth2UserService.createOrRetrieveUser(oauth2UserInfo);
+    // then
+    assertThat(res).isEqualTo(user);
+    verify(userRepository, times(1)).findByUserEmail(userEmail);
+    verify(userRepository, times(1)).save(user);
+  }
+
+  @Test
+  @DisplayName("if concurrency issue occurs, return user in DB")
+  void createOrRetrieveUser_whenConcurrencyIssueOccurs() {
+    // given
+    User user = User.builder().build();
+    given(oauth2UserInfo.toEntity())
+        .willReturn(user);
+    given(userRepository.findByUserEmail(userEmail))
+        .willReturn(Optional.empty())
+        .willReturn(Optional.of(user));
+    given(userRepository.save(user))
+        .willThrow(new DataIntegrityViolationException("exception"));
+    // when
+    User res = customOauth2UserService.createOrRetrieveUser(oauth2UserInfo);
+    // then
+    assertThat(res).isEqualTo(user);
+    verify(userRepository, times(2)).findByUserEmail(userEmail);
+    verify(userRepository, times(1)).save(user);
+  }
+}

--- a/src/test/java/com/komentum/global/security/cookie/TokenCookieManagerTest.java
+++ b/src/test/java/com/komentum/global/security/cookie/TokenCookieManagerTest.java
@@ -1,0 +1,65 @@
+package com.komentum.global.security.cookie;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.komentum.global.properties.AuthProperty;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class TokenCookieManagerTest {
+
+  TokenCookieManager tokenCookieManager;
+
+  private final AuthProperty authProperty = new AuthProperty(
+      1000L,
+      1000L,
+      "http://localhost:3000",
+      false
+  );
+
+  @BeforeEach
+  public void setUp() {
+    this.tokenCookieManager = new TokenCookieManager(authProperty);
+  }
+
+  private void assertTokenCookie(Cookie tokenCookie, String expectedValue) {
+    assertThat(tokenCookie).isNotNull();
+    assertThat(tokenCookie.isHttpOnly()).isTrue();
+    assertThat(tokenCookie.getValue()).isEqualTo(expectedValue);
+  }
+
+  @Test
+  void addTokenOnCookie() {
+    // given
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    String accessToken = "access-token";
+    String refreshToken = "refresh-token";
+    // when
+    tokenCookieManager.addTokenOnCookie(response, accessToken, refreshToken);
+    // then
+    Cookie accessTokenCookie = response.getCookie(AuthProperty.accessTokenCookieName);
+    Cookie refreshTokenCookie = response.getCookie(AuthProperty.refreshTokenCookieName);
+    assertTokenCookie(accessTokenCookie, accessToken);
+    assertTokenCookie(refreshTokenCookie, refreshToken);
+  }
+
+  @Test
+  void removeTokenOnCookie() {
+    // given
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    // when
+    tokenCookieManager.removeTokenOnCookie(response);
+    // then
+    Cookie accessTokenCookie = response.getCookie(AuthProperty.accessTokenCookieName);
+    Cookie refreshTokenCookie = response.getCookie(AuthProperty.refreshTokenCookieName);
+    assertThat(accessTokenCookie).isNotNull();
+    assertThat(refreshTokenCookie).isNotNull();
+    assertThat(accessTokenCookie.getMaxAge()).isEqualTo(0);
+    assertThat(refreshTokenCookie.getMaxAge()).isEqualTo(0);
+  }
+}

--- a/src/test/java/com/komentum/global/security/cookie/TokenCookieManagerTest.java
+++ b/src/test/java/com/komentum/global/security/cookie/TokenCookieManagerTest.java
@@ -42,8 +42,8 @@ class TokenCookieManagerTest {
     // when
     tokenCookieManager.addTokenOnCookie(response, accessToken, refreshToken);
     // then
-    Cookie accessTokenCookie = response.getCookie(AuthProperty.accessTokenCookieName);
-    Cookie refreshTokenCookie = response.getCookie(AuthProperty.refreshTokenCookieName);
+    Cookie accessTokenCookie = response.getCookie(AuthProperty.ACCESS_TOKEN_COOKIE_NAME);
+    Cookie refreshTokenCookie = response.getCookie(AuthProperty.REFRESH_TOKEN_COOKIE_NAME);
     assertTokenCookie(accessTokenCookie, accessToken);
     assertTokenCookie(refreshTokenCookie, refreshToken);
   }
@@ -55,8 +55,8 @@ class TokenCookieManagerTest {
     // when
     tokenCookieManager.removeTokenOnCookie(response);
     // then
-    Cookie accessTokenCookie = response.getCookie(AuthProperty.accessTokenCookieName);
-    Cookie refreshTokenCookie = response.getCookie(AuthProperty.refreshTokenCookieName);
+    Cookie accessTokenCookie = response.getCookie(AuthProperty.ACCESS_TOKEN_COOKIE_NAME);
+    Cookie refreshTokenCookie = response.getCookie(AuthProperty.REFRESH_TOKEN_COOKIE_NAME);
     assertThat(accessTokenCookie).isNotNull();
     assertThat(refreshTokenCookie).isNotNull();
     assertThat(accessTokenCookie.getMaxAge()).isEqualTo(0);

--- a/src/test/java/com/komentum/test/MockMvcUtils.java
+++ b/src/test/java/com/komentum/test/MockMvcUtils.java
@@ -48,8 +48,8 @@ public class MockMvcUtils {
   public MockHttpServletRequestBuilder addAuthentication(
       MockHttpServletRequestBuilder requestBuilder, String userIdentifier) {
     String jwtToken = jwtUtils.generateAccessToken(userIdentifier);
-    return requestBuilder.header(AuthProperty.ACCESS_TOKEN_HEADER,
-        AuthProperty.ACCESS_TOKEN_PREFIX + " " + jwtToken);
+    return requestBuilder.header(AuthProperty.accessTokenHeader,
+        AuthProperty.accessTokenPrefix + " " + jwtToken);
   }
 
   /**

--- a/src/test/java/com/komentum/test/MockMvcUtils.java
+++ b/src/test/java/com/komentum/test/MockMvcUtils.java
@@ -48,8 +48,8 @@ public class MockMvcUtils {
   public MockHttpServletRequestBuilder addAuthentication(
       MockHttpServletRequestBuilder requestBuilder, String userIdentifier) {
     String jwtToken = jwtUtils.generateAccessToken(userIdentifier);
-    return requestBuilder.header(AuthProperty.accessTokenHeader,
-        AuthProperty.accessTokenPrefix + " " + jwtToken);
+    return requestBuilder.header(AuthProperty.ACCESS_TOKEN_HEADER,
+        AuthProperty.ACCESS_TOKEN_PREFIX + " " + jwtToken);
   }
 
   /**


### PR DESCRIPTION
## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용

### 1. 인증 구조 개선
- Spring OAuth2 기반 카카오 소셜 로그인 기능 구현
- JWT 인증 방식을 헤더 기반에서 **쿠키 + 헤더 병행 방식**으로 확장
- 세션 기반 인증 제거 및 stateless 설정 적용

### 2. 토큰 관리 방식 변경
- 로그인 시 access/refresh 토큰을 HttpOnly 쿠키로 저장하도록 변경
- 로그아웃 시 쿠키 만료(maxAge=0) 방식으로 토큰 제거

### 3. 사용자 도메인 확장
- User 엔티티에 `authProvider` 필드 추가 (LOCAL / KAKAO 구분)

### 4. 설정 및 환경 분리
- 인증 관련 설정 값을 application.yml로 분리하여 환경별 설정 가능하도록 개선

### 5. 권한 처리 개선
- Spring Security에서 Role/Authority가 정상적으로 동작하도록 수정
  - 권한 부여 시 `ROLE_` prefix 적용
  - role 기반 접근 제어 시 prefix 없이 사용 (Spring Security 자동 처리)

관련 이슈: #81 


## 테스트 결과
<!-- 테스트 결과를 스크린 샷으로 첨부해주세요. -->
### 1. 단위 / 통합 테스트 결과 ( 테마 패키지 제외 모두 성공 )
<img width="1254" height="664" alt="image" src="https://github.com/user-attachments/assets/cce521c5-26ed-488a-95c4-7d7e28a7f0c0" />  

### 2. 수동 테스트 결과 ( React 환경에서 카카오 로그인 성공 )
<img width="604" height="657" alt="image" src="https://github.com/user-attachments/assets/db4ce9aa-a714-4415-807f-470704d7b755" />  

### 3. 수동 테스트 결과 ( 카카오 로그인 후 테마 게시글 조회 )
<img width="848" height="458" alt="image" src="https://github.com/user-attachments/assets/4accff49-9e48-4984-a175-7370c6e29715" />  

### 4. 수동 테스트 결과 ( 카카오 로그인 후 현재 사용자 정보 조회 )
<img width="1423" height="760" alt="image" src="https://github.com/user-attachments/assets/91120637-1f06-43e0-b7d8-956277290eff" />  

### 5. 수동 테스트 결과 ( 로그아웃 후 현재 사용자 정보 재조회 )
<img width="1423" height="773" alt="image" src="https://github.com/user-attachments/assets/1029b2cf-03ab-4dd1-8392-0d759074bb30" />


## PR 체크리스트
- [x] 커밋 메시지가 가이드라인을 따르는가
- [x] 테스트 코드를 모두 통과하였는가
- [x] 관련 이슈를 연결하였는가
