### PR TITLE
Feat/#90 게시글 상세 조회 리스트 API 개발

### DIFF
--- a/src/main/java/com/komentum/post/controller/DesignBoardController.java
+++ b/src/main/java/com/komentum/post/controller/DesignBoardController.java
@@ -7,6 +7,7 @@ import com.komentum.post.dto.DesignBoardDto.DesignBoardPreviewDto;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardUpdateDto;
 import com.komentum.post.facade.DesignBoardManagementFacade;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -54,6 +56,33 @@ public class DesignBoardController {
   ) {
     return ResponseEntity.ok(
         designBoardManagementFacade.findBoardDetail(postId, userDetails.getPublicUserId()));
+  }
+
+  /**
+   * 디자인 에셋 게시글 상세 정보 리스트 조회
+   * */
+  @GetMapping("/details")
+  @Operation(
+      summary = "인증된 사용자가 디자인 에셋 게시글 상세 목록을 조회한다",
+      description = """
+          
+          [동작 방식]
+          - pinned_post_id가 있는 경우
+            - 첫 페이지(page=0)에서 해당 게시글을 최상단에 고정한다.
+            - pinned_post_id가 null이 아니라면, pinned_post 작성자의 게시글만 조회한다.
+            - pinned_post는 page=0일 때만 게시된다.
+          - pinned_post_id가 없는 경우
+            - 일반적인 페이징 기반 조회로 동작한다.
+          """)
+  public ResponseEntity<List<DesignBoardDetailDto>> findDesignBoardDetails(
+      @Parameter(description = "첫 번째 페이지 최상단에 고정할 게시글 ID")
+      @RequestParam(value = "pinned_post_id", required = false) Long pinnedPostId,
+      @PageableDefault(size = 20, sort = "createdAt") @ParameterObject Pageable pageable,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    List<DesignBoardDetailDto> response = designBoardManagementFacade
+        .findBoardDetails(pageable, pinnedPostId, userDetails.getUsername());
+    return ResponseEntity.ok(response);
   }
 
   /**

--- a/src/main/java/com/komentum/post/controller/ThemeBoardController.java
+++ b/src/main/java/com/komentum/post/controller/ThemeBoardController.java
@@ -7,6 +7,7 @@ import com.komentum.post.dto.ThemeBoardDto.ThemeBoardPreviewDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardUpdateDto;
 import com.komentum.post.facade.ThemeBoardManagementFacade;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -83,6 +85,30 @@ public class ThemeBoardController {
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     return ResponseEntity.ok(
         themeBoardManagementFacade.findThemeBoardDetail(postId, userDetails.getUsername()));
+  }
+
+  @GetMapping("/details")
+  @Operation(
+      summary = "인증된 사용자가 게시글 상세 목록을 조회한다",
+      description = """
+          
+          [동작 방식]
+          - pinned_post_id가 있는 경우
+            - 첫 페이지(page=0)에서 해당 게시글을 최상단에 고정한다.
+            - pinned_post_id가 null이 아니라면, pinned_post 작성자의 게시글만 조회한다.
+            - pinned_post는 page=0일 때만 게시된다.
+          - pinned_post_id가 없는 경우
+            - 일반적인 페이징 기반 조회로 동작한다.
+          """)
+  public ResponseEntity<List<ThemeBoardDetailDto>> findThemeBoardDetails(
+      @Parameter(description = "첫 번째 페이지 최상단에 고정할 게시글 ID")
+      @RequestParam(value = "pinned_post_id", required = false) Long pinnedPostId,
+      @PageableDefault(size = 20, sort = "createdAt") @ParameterObject Pageable pageable,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    List<ThemeBoardDetailDto> response = themeBoardManagementFacade.findThemeBoardDetails(pageable,
+        pinnedPostId, userDetails.getUsername());
+    return ResponseEntity.ok(response);
   }
 
   /**

--- a/src/main/java/com/komentum/post/controller/ThemeBoardController.java
+++ b/src/main/java/com/komentum/post/controller/ThemeBoardController.java
@@ -89,7 +89,7 @@ public class ThemeBoardController {
 
   @GetMapping("/details")
   @Operation(
-      summary = "인증된 사용자가 게시글 상세 목록을 조회한다",
+      summary = "인증된 사용자가 테마 게시글 상세 목록을 조회한다",
       description = """
           
           [동작 방식]

--- a/src/main/java/com/komentum/post/dto/DesignBoardDto.java
+++ b/src/main/java/com/komentum/post/dto/DesignBoardDto.java
@@ -48,7 +48,7 @@ public class DesignBoardDto {
 
     @Schema(description = "게시글 대표 이미지 URL", example = "https://sample.com")
     @JsonProperty("preview_image_url")
-    private String previewImageUrl;
+    private List<String> previewImageUrl;
 
     @Schema(description = "게시글 좋아요 수")
     private Long prefers;
@@ -64,6 +64,10 @@ public class DesignBoardDto {
 
     @Schema(description = "현재 사용자의 북마크 저장 여부")
     private boolean bookmarked;
+
+    @Schema(description = "게시글 작성자 프로필 이미지 URL")
+    @JsonProperty("profile_image")
+    private String profileImage;
   }
 
   @Data

--- a/src/main/java/com/komentum/post/dto/ThemeBoardDto.java
+++ b/src/main/java/com/komentum/post/dto/ThemeBoardDto.java
@@ -49,7 +49,7 @@ public class ThemeBoardDto {
 
     @Schema(description = "게시글 대표 이미지 URL", example = "https://sample.com")
     @JsonProperty("preview_image_url")
-    private String previewImageUrl;
+    private List<String> previewImageUrl;
 
     @Schema(description = "게시글 좋아요 수")
     private Long prefers;
@@ -65,6 +65,10 @@ public class ThemeBoardDto {
 
     @Schema(description = "현재 사용자의 북마크 저장 여부")
     private boolean bookmarked;
+
+    @Schema(description = "사용자 프로필 이미지")
+    @JsonProperty("profile_image")
+    private String profileImage;
   }
 
   @Data

--- a/src/main/java/com/komentum/post/dto/query/DesignBoardQuery.java
+++ b/src/main/java/com/komentum/post/dto/query/DesignBoardQuery.java
@@ -23,6 +23,7 @@ public class DesignBoardQuery {
     private Long comments;
     private boolean liked;
     private boolean bookmarked;
+    private String profileImage;
 
     @QueryProjection
     public Detail(
@@ -37,7 +38,8 @@ public class DesignBoardQuery {
         Long prefers,
         Long comments,
         boolean liked,
-        boolean bookmarked) {
+        boolean bookmarked,
+        String profileImage) {
       this.postId = postId;
       this.title = title;
       this.content = content;
@@ -50,6 +52,7 @@ public class DesignBoardQuery {
       this.comments = comments;
       this.liked = liked;
       this.bookmarked = bookmarked;
+      this.profileImage = profileImage;
     }
   }
 

--- a/src/main/java/com/komentum/post/dto/query/ThemeBoardQuery.java
+++ b/src/main/java/com/komentum/post/dto/query/ThemeBoardQuery.java
@@ -58,6 +58,7 @@ public class ThemeBoardQuery {
     private Long comments;
     private boolean liked;
     private boolean bookmarked;
+    private String profileImage; // 사용자 프로필 이미지
 
     @QueryProjection
     public Detail(
@@ -72,7 +73,8 @@ public class ThemeBoardQuery {
         Long prefers,
         Long comments,
         boolean liked,
-        boolean bookmarked) {
+        boolean bookmarked,
+        String profileImage) {
       this.postId = postId;
       this.title = title;
       this.content = content;
@@ -85,6 +87,7 @@ public class ThemeBoardQuery {
       this.comments = comments;
       this.liked = liked;
       this.bookmarked = bookmarked;
+      this.profileImage = profileImage;
     }
   }
 }

--- a/src/main/java/com/komentum/post/facade/DesignBoardManagementFacade.java
+++ b/src/main/java/com/komentum/post/facade/DesignBoardManagementFacade.java
@@ -2,21 +2,26 @@ package com.komentum.post.facade;
 
 import com.komentum.global.utils.FileManager;
 import com.komentum.post.domain.Post;
+import com.komentum.post.domain.Tag;
+import com.komentum.post.domain.enums.PostType;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardCreateDto;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardDetailDto;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardPreviewDto;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardUpdateDto;
 import com.komentum.post.dto.query.DesignBoardQuery;
+import com.komentum.post.dto.query.DesignBoardQuery.Detail;
 import com.komentum.post.mapper.DesignBoardMapperSupport;
 import com.komentum.post.mapper.PostDtoMapper;
 import com.komentum.post.service.DesignBoardService;
 import com.komentum.post.service.PostService;
+import com.komentum.post.service.TagService;
 import com.komentum.post.service.transaction.DesignBoardTransactionService;
 import com.komentum.theme.component.domain.DesignComponent;
 import com.komentum.theme.component.service.DesignComponentService;
 import com.komentum.user.domain.User;
 import com.komentum.user.service.UserEntityFinder;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +45,7 @@ public class DesignBoardManagementFacade {
 
   // mapper
   private final PostDtoMapper postDtoMapper;
+  private final TagService tagService;
 
   private String uploadOrReusePreviewImage(
       MultipartFile previewImage,
@@ -76,6 +82,25 @@ public class DesignBoardManagementFacade {
         .map(p ->
             designBoardMapperSupport.toDesignBoardPreviewDto(p, boardManagementHelper))
         .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public List<DesignBoardDetailDto> findBoardDetails(Pageable pageable, Long pinnedPostId,
+      String userIdentifier) {
+    User client = userEntityFinder.findUserEntity(userIdentifier);
+    Post pinnedPost = pinnedPostId == null ?
+        null :
+        postService.findByPostIdAndPostType(pinnedPostId, PostType.DESIGN_BOARD);
+    List<DesignBoardQuery.Detail> details = designBoardService.findDetailList(pageable, client,
+        pinnedPost);
+    List<Long> postIds = details.stream()
+        .map(Detail::getPostId)
+        .toList();
+    Map<Long, List<Tag>> tagMap = tagService.getTagPerPosts(postIds);
+    return details.stream().map(detail -> {
+      List<Tag> tags = tagMap.getOrDefault(detail.getPostId(), List.of());
+      return designBoardMapperSupport.toDesignBoardDetailDto(detail, boardManagementHelper, tags);
+    }).toList();
   }
 
   /**

--- a/src/main/java/com/komentum/post/facade/ThemeBoardManagementFacade.java
+++ b/src/main/java/com/komentum/post/facade/ThemeBoardManagementFacade.java
@@ -3,14 +3,16 @@ package com.komentum.post.facade;
 import com.komentum.global.utils.FileManager;
 import com.komentum.post.consts.ThemeBoardConsts;
 import com.komentum.post.domain.Post;
+import com.komentum.post.domain.Tag;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardCreateDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardDetailDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardPreviewDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardUpdateDto;
 import com.komentum.post.dto.query.ThemeBoardQuery;
-import com.komentum.post.mapper.PostDtoMapper;
+import com.komentum.post.dto.query.ThemeBoardQuery.Detail;
 import com.komentum.post.mapper.ThemeBoardMapperSupport;
 import com.komentum.post.service.PostService;
+import com.komentum.post.service.TagService;
 import com.komentum.post.service.ThemeBoardService;
 import com.komentum.post.service.transaction.ThemeBoardTransactionService;
 import com.komentum.theme.component.domain.DesignComponent;
@@ -21,6 +23,7 @@ import com.komentum.theme.theme.service.ThemeRetrieveService;
 import com.komentum.user.domain.User;
 import com.komentum.user.service.UserEntityFinder;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -39,10 +42,10 @@ public class ThemeBoardManagementFacade {
   private final ThemeRetrieveService themeRetrieveService;
   private final BoardManagementHelper boardManagementHelper;
   private final ThemeBoardMapperSupport themeBoardMapperSupport;
-  private final PostDtoMapper postDtoMapper;
   private final ThemeImageService themeImageService;
   private final FileManager fileManager;
   private final ThemeBoardTransactionService themeBoardTransactionService;
+  private final TagService tagService;
 
   private String uploadOrReusePreviewImage(MultipartFile previewImage,
       ThemeComponent themeComponent) {
@@ -70,6 +73,29 @@ public class ThemeBoardManagementFacade {
   @Transactional
   public ThemeBoardDetailDto findThemeBoardDetail(Long postId, String userIdentifier) {
     return themeBoardTransactionService.findThemeBoardDetail(postId, userIdentifier);
+  }
+
+  /**
+   * 게시글 상세 정보 목록 조회
+   * @param pageable 페이지 정보
+   * @param pinnedPostId 맨 앞에 제시할 게시글 정보
+   * @param userIdentifier 현재 사용자 식별자
+   * */
+  @Transactional(readOnly = true)
+  public List<ThemeBoardDetailDto> findThemeBoardDetails(Pageable pageable, Long pinnedPostId,
+      String userIdentifier) {
+    User client = userEntityFinder.findUserEntity(userIdentifier);
+    Post pinnedPost = pinnedPostId == null ? null : postService.getPostByPostId(pinnedPostId);
+    List<ThemeBoardQuery.Detail> details = themeBoardService.findThemeBoardQueryDetailList(pageable,
+        client, pinnedPost);
+    List<Long> postIds = details.stream()
+        .map(Detail::getPostId)
+        .toList();
+    Map<Long, List<Tag>> tagMap = tagService.getTagPerPosts(postIds);
+    return details.stream().map(detail -> {
+      List<Tag> tags = tagMap.getOrDefault(detail.getPostId(), List.of());
+      return themeBoardMapperSupport.toThemeBoardDetailDto(detail, tags, boardManagementHelper);
+    }).toList();
   }
 
   /**

--- a/src/main/java/com/komentum/post/facade/ThemeBoardManagementFacade.java
+++ b/src/main/java/com/komentum/post/facade/ThemeBoardManagementFacade.java
@@ -4,6 +4,7 @@ import com.komentum.global.utils.FileManager;
 import com.komentum.post.consts.ThemeBoardConsts;
 import com.komentum.post.domain.Post;
 import com.komentum.post.domain.Tag;
+import com.komentum.post.domain.enums.PostType;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardCreateDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardDetailDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardPreviewDto;
@@ -85,7 +86,9 @@ public class ThemeBoardManagementFacade {
   public List<ThemeBoardDetailDto> findThemeBoardDetails(Pageable pageable, Long pinnedPostId,
       String userIdentifier) {
     User client = userEntityFinder.findUserEntity(userIdentifier);
-    Post pinnedPost = pinnedPostId == null ? null : postService.getPostByPostId(pinnedPostId);
+    Post pinnedPost = pinnedPostId == null ?
+        null :
+        postService.findByPostIdAndPostType(pinnedPostId, PostType.THEME_BOARD);
     List<ThemeBoardQuery.Detail> details = themeBoardService.findThemeBoardQueryDetailList(pageable,
         client, pinnedPost);
     List<Long> postIds = details.stream()

--- a/src/main/java/com/komentum/post/mapper/DesignBoardMapperSupport.java
+++ b/src/main/java/com/komentum/post/mapper/DesignBoardMapperSupport.java
@@ -33,6 +33,8 @@ public class DesignBoardMapperSupport {
       BoardManagementHelper helper,
       List<Tag> tags
   ) {
+    String previewImageUrl = helper.findPreviewImageUrl(detail.getPreviewImageName());
+    List<String> previewImageList = previewImageUrl == null ? List.of() : List.of(previewImageUrl);
     return DesignBoardDetailDto.builder()
         .postId(detail.getPostId())
         .title(detail.getTitle())
@@ -40,9 +42,7 @@ public class DesignBoardMapperSupport {
         .designComponentId(detail.getDesignComponentId())
         .userEmail(detail.getUserEmail())
         .createdAt(DateUtils.convertToDateString(detail.getCreatedAt()))
-        .previewImageUrl(
-            List.of(helper.findPreviewImageUrl(detail.getPreviewImageName()))
-        )
+        .previewImageUrl(previewImageList)
         .prefers(detail.getPrefers())
         .comments(detail.getComments())
         .tags(tags.stream().map(TagResponse::from).toList())

--- a/src/main/java/com/komentum/post/mapper/DesignBoardMapperSupport.java
+++ b/src/main/java/com/komentum/post/mapper/DesignBoardMapperSupport.java
@@ -41,13 +41,14 @@ public class DesignBoardMapperSupport {
         .userEmail(detail.getUserEmail())
         .createdAt(DateUtils.convertToDateString(detail.getCreatedAt()))
         .previewImageUrl(
-            helper.findPreviewImageUrl(detail.getPreviewImageName())
+            List.of(helper.findPreviewImageUrl(detail.getPreviewImageName()))
         )
         .prefers(detail.getPrefers())
         .comments(detail.getComments())
         .tags(tags.stream().map(TagResponse::from).toList())
         .liked(detail.isLiked())
         .bookmarked(detail.isBookmarked())
+        .profileImage(detail.getProfileImage())
         .build();
   }
 }

--- a/src/main/java/com/komentum/post/mapper/ThemeBoardMapperSupport.java
+++ b/src/main/java/com/komentum/post/mapper/ThemeBoardMapperSupport.java
@@ -49,12 +49,13 @@ public class ThemeBoardMapperSupport {
         .userEmail(detail.getUserEmail())
         .userName(detail.getUserName())
         .createdAt(DateUtils.convertToDateString(detail.getCreatedAt()))
-        .previewImageUrl(helper.findPreviewImageUrl(detail.getPreviewImageName()))
+        .previewImageUrl(List.of(helper.findPreviewImageUrl(detail.getPreviewImageName())))
         .prefers(detail.getPrefers())
         .comments(detail.getComments())
         .tags(tags.stream().map(TagResponse::from).toList())
         .liked(detail.isLiked())
         .bookmarked(detail.isBookmarked())
+        .profileImage(detail.getProfileImage())
         .build();
   }
 }

--- a/src/main/java/com/komentum/post/mapper/ThemeBoardMapperSupport.java
+++ b/src/main/java/com/komentum/post/mapper/ThemeBoardMapperSupport.java
@@ -41,6 +41,8 @@ public class ThemeBoardMapperSupport {
    * */
   public ThemeBoardDetailDto toThemeBoardDetailDto(ThemeBoardQuery.Detail detail, List<Tag> tags,
       BoardManagementHelper helper) {
+    String previewImageUrl = helper.findPreviewImageUrl(detail.getPreviewImageName());
+    List<String> previewImageList = previewImageUrl == null ? List.of() : List.of(previewImageUrl);
     return ThemeBoardDetailDto.builder()
         .postId(detail.getPostId())
         .title(detail.getTitle())
@@ -49,7 +51,7 @@ public class ThemeBoardMapperSupport {
         .userEmail(detail.getUserEmail())
         .userName(detail.getUserName())
         .createdAt(DateUtils.convertToDateString(detail.getCreatedAt()))
-        .previewImageUrl(List.of(helper.findPreviewImageUrl(detail.getPreviewImageName())))
+        .previewImageUrl(previewImageList)
         .prefers(detail.getPrefers())
         .comments(detail.getComments())
         .tags(tags.stream().map(TagResponse::from).toList())

--- a/src/main/java/com/komentum/post/repository/DesignBoardRepositorySupport.java
+++ b/src/main/java/com/komentum/post/repository/DesignBoardRepositorySupport.java
@@ -7,10 +7,16 @@ import com.komentum.post.domain.QPrefer;
 import com.komentum.post.dto.query.DesignBoardQuery;
 import com.komentum.post.dto.query.QDesignBoardQuery_Detail;
 import com.komentum.post.dto.query.QDesignBoardQuery_Preview;
+import com.komentum.post.service.condition.PostSearchCondition;
+import com.komentum.post.service.enums.PostSortType;
 import com.komentum.theme.component.domain.QDesignComponent;
 import com.komentum.user.domain.QUser;
 import com.komentum.user.domain.User;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,15 +30,26 @@ public class DesignBoardRepositorySupport {
   private final JPAQueryFactory queryFactory;
   private final PostRepositorySupport postRepositorySupport;
 
-  public DesignBoardQuery.Detail findDetailByPostId(Long postId, User client) {
+  public JPAQuery<DesignBoardQuery.Detail> getDesignBoardDetailBaseQuery(User client) {
     QPost post = QPost.post;
     QDesignBoard designBoard = QDesignBoard.designBoard;
     QPrefer prefer = QPrefer.prefer;
     QComment comment = QComment.comment;
     QUser user = QUser.user;
     QDesignComponent designComponent = QDesignComponent.designComponent;
-    NumberExpression<Long> preferCount = prefer.countDistinct();
-    NumberExpression<Long> commentCount = comment.countDistinct();
+
+    JPQLQuery<Long> preferCount =
+        JPAExpressions
+            .select(prefer.count())
+            .from(prefer)
+            .where(prefer.post.eq(post));
+
+    JPQLQuery<Long> commentCount =
+        JPAExpressions
+            .select(comment.count())
+            .from(comment)
+            .where(comment.post.eq(post));
+
     return queryFactory.select(
             new QDesignBoardQuery_Detail(
                 post.postId,
@@ -46,17 +63,40 @@ public class DesignBoardRepositorySupport {
                 preferCount,
                 commentCount,
                 postRepositorySupport.isLiked(post, client),
-                postRepositorySupport.isBookmarked(post, client)
+                postRepositorySupport.isBookmarked(post, client),
+                user.profileImg
             )
         )
         .from(designBoard)
         .join(designBoard.designComponent, designComponent)
         .join(designBoard.post, post)
-        .join(post.user, user)
-        .leftJoin(prefer).on(prefer.post.eq(post))
-        .leftJoin(comment).on(comment.post.eq(post))
+        .join(post.user, user);
+  }
+
+  public DesignBoardQuery.Detail findDetailByPostId(Long postId, User client) {
+    QPost post = QPost.post;
+    return getDesignBoardDetailBaseQuery(client)
         .where(post.postId.eq(postId))
         .fetchOne();
+  }
+
+  public List<DesignBoardQuery.Detail> findDesignBoardDetails(
+      Pageable pageable,
+      User client,
+      PostSearchCondition condition,
+      List<PostSortType> sortTypes
+  ) {
+    QPost post = QPost.post;
+    List<OrderSpecifier<?>> orderSpecifiers = List.of();
+    PostOrder.addPinnedOrder(post, orderSpecifiers, condition.getPinnedPostIds());
+    return getDesignBoardDetailBaseQuery(client)
+        .where(
+            PostPredicate.userPublicIdEq(post, condition.getAuthorPublicId())
+        )
+        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+        .limit(pageable.getPageSize())
+        .offset(pageable.getOffset())
+        .fetch();
   }
 
   public List<DesignBoardQuery.Preview> findPreviewList(Pageable pageable) {

--- a/src/main/java/com/komentum/post/repository/DesignBoardRepositorySupport.java
+++ b/src/main/java/com/komentum/post/repository/DesignBoardRepositorySupport.java
@@ -18,6 +18,7 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -87,7 +88,7 @@ public class DesignBoardRepositorySupport {
       List<PostSortType> sortTypes
   ) {
     QPost post = QPost.post;
-    List<OrderSpecifier<?>> orderSpecifiers = List.of();
+    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
     PostOrder.addPinnedOrder(post, orderSpecifiers, condition.getPinnedPostIds());
     return getDesignBoardDetailBaseQuery(client)
         .where(

--- a/src/main/java/com/komentum/post/repository/DesignBoardRepositorySupport.java
+++ b/src/main/java/com/komentum/post/repository/DesignBoardRepositorySupport.java
@@ -18,7 +18,6 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -88,13 +87,12 @@ public class DesignBoardRepositorySupport {
       List<PostSortType> sortTypes
   ) {
     QPost post = QPost.post;
-    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
-    PostOrder.addPinnedOrder(post, orderSpecifiers, condition.getPinnedPostIds());
+    OrderSpecifier<?>[] orderSpecifiers = PostOrder.create(condition, sortTypes, post, null);
     return getDesignBoardDetailBaseQuery(client)
         .where(
             PostPredicate.userPublicIdEq(post, condition.getAuthorPublicId())
         )
-        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+        .orderBy(orderSpecifiers)
         .limit(pageable.getPageSize())
         .offset(pageable.getOffset())
         .fetch();

--- a/src/main/java/com/komentum/post/repository/PostOrder.java
+++ b/src/main/java/com/komentum/post/repository/PostOrder.java
@@ -22,6 +22,32 @@ public class PostOrder {
     orders.add(priority.asc());
   }
 
+  public static void addOrderSpecifiers(
+      List<PostSortType> sortTypeList,
+      QPost post,
+      List<OrderSpecifier<?>> orderSpecifiers,
+      NumberExpression<Long> preferCount) {
+
+    sortTypeList.forEach(sortType -> {
+      OrderSpecifier<?> orderSpecifier = switch (sortType) {
+        case DEFAULT -> post.createdAt.desc();
+        case PREFER_ASC -> {
+          if (preferCount == null) {
+            throw new IllegalArgumentException("preferCount is null");
+          }
+          yield preferCount.asc();
+        }
+        case PREFER_DESC -> {
+          if (preferCount == null) {
+            throw new IllegalArgumentException("preferCount is null");
+          }
+          yield preferCount.desc();
+        }
+      };
+      orderSpecifiers.add(orderSpecifier);
+    });
+  }
+
   public static OrderSpecifier<?>[] create(
       PostSearchCondition condition,
       List<PostSortType> sortTypes,
@@ -31,13 +57,7 @@ public class PostOrder {
     List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
     addPinnedOrder(post, orderSpecifiers, condition.getPinnedPostIds());
     if (sortTypes != null && !sortTypes.isEmpty()) {
-      for (PostSortType sortType : sortTypes) {
-        switch (sortType) {
-          case DEFAULT -> orderSpecifiers.add(post.createdAt.desc());
-          case PREFER_ASC -> orderSpecifiers.add(preferCount.asc());
-          case PREFER_DESC -> orderSpecifiers.add(preferCount.desc());
-        }
-      }
+      addOrderSpecifiers(sortTypes, post, orderSpecifiers, preferCount);
     }
     return orderSpecifiers.toArray(new OrderSpecifier[0]);
   }

--- a/src/main/java/com/komentum/post/repository/PostOrder.java
+++ b/src/main/java/com/komentum/post/repository/PostOrder.java
@@ -1,0 +1,44 @@
+package com.komentum.post.repository;
+
+import com.komentum.post.domain.QPost;
+import com.komentum.post.service.condition.PostSearchCondition;
+import com.komentum.post.service.enums.PostSortType;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PostOrder {
+
+  public static void addPinnedOrder(QPost post, List<OrderSpecifier<?>> orders,
+      List<Long> pinnedPostIds) {
+    if (pinnedPostIds == null) {
+      return;
+    }
+    NumberExpression<Integer> priority = new CaseBuilder()
+        .when(post.postId.in(pinnedPostIds)).then(0)
+        .otherwise(1);
+    orders.add(priority.asc());
+  }
+
+  public static OrderSpecifier<?>[] create(
+      PostSearchCondition condition,
+      List<PostSortType> sortTypes,
+      QPost post,
+      NumberExpression<Long> preferCount
+  ) {
+    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+    addPinnedOrder(post, orderSpecifiers, condition.getPinnedPostIds());
+    if (sortTypes != null && !sortTypes.isEmpty()) {
+      for (PostSortType sortType : sortTypes) {
+        switch (sortType) {
+          case DEFAULT -> orderSpecifiers.add(post.createdAt.desc());
+          case PREFER_ASC -> orderSpecifiers.add(preferCount.asc());
+          case PREFER_DESC -> orderSpecifiers.add(preferCount.desc());
+        }
+      }
+    }
+    return orderSpecifiers.toArray(new OrderSpecifier[0]);
+  }
+}

--- a/src/main/java/com/komentum/post/repository/PostPredicate.java
+++ b/src/main/java/com/komentum/post/repository/PostPredicate.java
@@ -1,0 +1,14 @@
+package com.komentum.post.repository;
+
+import com.komentum.post.domain.QPost;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class PostPredicate {
+
+  public static BooleanExpression userPublicIdEq(QPost post, String publicUserId) {
+    if (publicUserId == null) {
+      return null;
+    }
+    return post.user.publicUserId.eq(publicUserId);
+  }
+}

--- a/src/main/java/com/komentum/post/repository/PostRepository.java
+++ b/src/main/java/com/komentum/post/repository/PostRepository.java
@@ -1,9 +1,11 @@
 package com.komentum.post.repository;
 
 import com.komentum.post.domain.Post;
+import com.komentum.post.domain.enums.PostType;
 import com.komentum.user.domain.User;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,4 +18,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
   List<Post> findByUser_PublicUserId(String publicUserId);
 
   List<Post> findByUserIn(Collection<User> users);
+
+  Optional<Post> findByPostIdAndPostType(Long postId, PostType postType);
 }

--- a/src/main/java/com/komentum/post/repository/ThemeBoardRepositorySupport.java
+++ b/src/main/java/com/komentum/post/repository/ThemeBoardRepositorySupport.java
@@ -19,7 +19,6 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -141,13 +140,12 @@ public class ThemeBoardRepositorySupport {
   public List<ThemeBoardQuery.Detail> findThemeBoardQueryDetails(Pageable pageable, User client,
       PostSearchCondition condition, List<PostSortType> sortTypes) {
     QPost post = QPost.post;
-    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
-    PostOrder.addPinnedOrder(post, orderSpecifiers, condition.getPinnedPostIds());
+    OrderSpecifier<?>[] orderSpecifiers = PostOrder.create(condition, sortTypes, post, null);
     return getThemeBoardDetailBaseQuery(client)
         .where(
             PostPredicate.userPublicIdEq(post, condition.getAuthorPublicId())
         )
-        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+        .orderBy(orderSpecifiers)
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();

--- a/src/main/java/com/komentum/post/repository/ThemeBoardRepositorySupport.java
+++ b/src/main/java/com/komentum/post/repository/ThemeBoardRepositorySupport.java
@@ -8,13 +8,18 @@ import com.komentum.post.dto.query.QThemeBoardQuery_Detail;
 import com.komentum.post.dto.query.QThemeBoardQuery_Preview;
 import com.komentum.post.dto.query.ThemeBoardQuery;
 import com.komentum.post.dto.query.ThemeBoardQuery.Preview;
+import com.komentum.post.service.condition.PostSearchCondition;
 import com.komentum.post.service.enums.PostSortType;
 import com.komentum.theme.theme.domain.QThemeComponent;
 import com.komentum.user.domain.QUser;
 import com.komentum.user.domain.User;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -75,15 +80,29 @@ public class ThemeBoardRepositorySupport {
         .fetch();
   }
 
-  public ThemeBoardQuery.Detail findThemeBoardQueryDetail(Long postId, User client) {
+  /**
+   * ThemeBoardQuery.Detail 조회를 위한 공통 부분 분리
+   * */
+  private JPAQuery<ThemeBoardQuery.Detail> getThemeBoardDetailBaseQuery(User client) {
     QPost post = QPost.post;
     QPrefer prefer = QPrefer.prefer;
     QComment comment = QComment.comment;
     QUser user = QUser.user;
     QThemeBoard themeBoard = QThemeBoard.themeBoard;
     QThemeComponent themeComponent = QThemeComponent.themeComponent;
-    NumberExpression<Long> preferCount = prefer.countDistinct();
-    NumberExpression<Long> commentCount = comment.countDistinct();
+
+    JPQLQuery<Long> preferCount =
+        JPAExpressions
+            .select(prefer.count())
+            .from(prefer)
+            .where(prefer.post.eq(post));
+
+    JPQLQuery<Long> commentCount =
+        JPAExpressions
+            .select(comment.count())
+            .from(comment)
+            .where(comment.post.eq(post));
+
     return queryFactory
         .select(new QThemeBoardQuery_Detail(
             post.postId,
@@ -97,16 +116,41 @@ public class ThemeBoardRepositorySupport {
             preferCount,
             commentCount,
             postRepositorySupport.isLiked(post, client),
-            postRepositorySupport.isBookmarked(post, client)
+            postRepositorySupport.isBookmarked(post, client),
+            user.profileImg
         ))
         .from(themeBoard)
         .join(themeBoard.themeComponent, themeComponent)
         .join(themeBoard.post, post)
-        .join(post.user, user)
-        .leftJoin(prefer).on(prefer.post.eq(post))
-        .leftJoin(comment).on(comment.post.eq(post))
+        .join(post.user, user);
+  }
+
+  /**
+   * 테마 게시글 상세 정보 단건 조회
+   * */
+  public ThemeBoardQuery.Detail findThemeBoardQueryDetail(Long postId, User client) {
+    QPost post = QPost.post;
+    return getThemeBoardDetailBaseQuery(client)
         .where(post.postId.eq(postId))
         .fetchOne();
+  }
+
+  /**
+   * 테마 게시글 목록 상세 정보 일괄 조회
+   * */
+  public List<ThemeBoardQuery.Detail> findThemeBoardQueryDetails(Pageable pageable, User client,
+      PostSearchCondition condition, List<PostSortType> sortTypes) {
+    QPost post = QPost.post;
+    List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+    PostOrder.addPinnedOrder(post, orderSpecifiers, condition.getPinnedPostIds());
+    return getThemeBoardDetailBaseQuery(client)
+        .where(
+            PostPredicate.userPublicIdEq(post, condition.getAuthorPublicId())
+        )
+        .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
   }
 
   /**

--- a/src/main/java/com/komentum/post/service/DesignBoardService.java
+++ b/src/main/java/com/komentum/post/service/DesignBoardService.java
@@ -8,9 +8,12 @@ import com.komentum.post.dto.query.DesignBoardQuery;
 import com.komentum.post.mapper.PostDtoMapper;
 import com.komentum.post.repository.DesignBoardRepository;
 import com.komentum.post.repository.DesignBoardRepositorySupport;
+import com.komentum.post.service.condition.PostSearchCondition;
+import com.komentum.post.service.enums.PostSortType;
 import com.komentum.theme.component.domain.DesignComponent;
 import com.komentum.user.domain.User;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -49,6 +52,25 @@ public class DesignBoardService {
   public DesignBoard findByPostId(long postId) {
     return designBoardRepository.findByPost_PostId(postId)
         .orElseThrow(() -> new CustomEntityNotFoundException(DesignBoard.class, postId));
+  }
+
+  @Transactional(readOnly = true)
+  public List<DesignBoardQuery.Detail> findDetailList(Pageable pageable, User client,
+      Post pinnedPost) {
+    PostSearchCondition condition = new PostSearchCondition();
+    if (pinnedPost != null) {
+      condition = condition
+          .withPinnedPostIds(List.of(pinnedPost.getPostId()))
+          .withAuthorPublicId(pinnedPost.getUser().getPublicUserId());
+    }
+    return new ArrayList<>(
+        designBoardRepositorySupport.findDesignBoardDetails(
+            pageable,
+            client,
+            condition,
+            List.of(PostSortType.DEFAULT)
+        )
+    );
   }
 
   @Transactional

--- a/src/main/java/com/komentum/post/service/PostService.java
+++ b/src/main/java/com/komentum/post/service/PostService.java
@@ -44,6 +44,12 @@ public class PostService {
     return postRepository.findByUser_PublicUserId(publicUserId);
   }
 
+  public Post findByPostIdAndPostType(Long postId, PostType postType) {
+    return postRepository.findByPostIdAndPostType(postId, postType)
+        .orElseThrow(() -> new EntityNotFoundException(
+            "cannot find " + postType.name() + " post with id : " + postId));
+  }
+
   /**
    * 게시글 생성
    *

--- a/src/main/java/com/komentum/post/service/ThemeBoardService.java
+++ b/src/main/java/com/komentum/post/service/ThemeBoardService.java
@@ -7,8 +7,11 @@ import com.komentum.post.dto.query.ThemeBoardQuery;
 import com.komentum.post.mapper.PostDtoMapper;
 import com.komentum.post.repository.ThemeBoardRepository;
 import com.komentum.post.repository.ThemeBoardRepositorySupport;
+import com.komentum.post.service.condition.PostSearchCondition;
 import com.komentum.post.service.enums.PostSortType;
 import com.komentum.theme.theme.domain.ThemeComponent;
+import com.komentum.user.domain.User;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -47,6 +50,31 @@ public class ThemeBoardService {
         PostSortType.PREFER_DESC :
         PostSortType.PREFER_ASC;
     return themeBoardRepositorySupport.findThemeBoardQueryPreviewList(pageable, List.of(sortType));
+  }
+
+  /**
+   * 조건에 따라 게시글 상세 정보를 조회한다
+   * @param pageable 조회할 페이지 정보
+   * @param client 조회에 사용할 사용자 정보
+   * @param pinnedPost pageNumber=0일 때, 결과 맨 앞에 포함할 게시글 정보
+   * */
+  public List<ThemeBoardQuery.Detail> findThemeBoardQueryDetailList(Pageable pageable, User client,
+      Post pinnedPost) {
+    PostSearchCondition condition = new PostSearchCondition();
+    if (pinnedPost != null) {
+      // post에 대한 condition 추가
+      condition = condition
+          .withPinnedPostIds(List.of(pinnedPost.getPostId()))
+          .withAuthorPublicId(pinnedPost.getUser().getPublicUserId());
+    }
+    return new ArrayList<>(
+        themeBoardRepositorySupport.findThemeBoardQueryDetails(
+            pageable,
+            client,
+            condition,
+            List.of(PostSortType.DEFAULT)
+        )
+    );
   }
 
   /**

--- a/src/main/java/com/komentum/post/service/condition/PostSearchCondition.java
+++ b/src/main/java/com/komentum/post/service/condition/PostSearchCondition.java
@@ -1,0 +1,24 @@
+package com.komentum.post.service.condition;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class PostSearchCondition {
+
+  private String authorPublicId;
+  private List<Long> pinnedPostIds = new ArrayList<>();
+
+  public PostSearchCondition withAuthorPublicId(String authorPublicId) {
+    this.authorPublicId = authorPublicId;
+    return this;
+  }
+
+  public PostSearchCondition withPinnedPostIds(List<Long> pinnedPostIds) {
+    this.pinnedPostIds = pinnedPostIds;
+    return this;
+  }
+}

--- a/src/main/java/com/komentum/post/service/condition/PostSearchCondition.java
+++ b/src/main/java/com/komentum/post/service/condition/PostSearchCondition.java
@@ -2,10 +2,12 @@ package com.komentum.post.service.condition;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 public class PostSearchCondition {
 

--- a/src/test/java/com/komentum/post/controller/DesignBoardControllerTest.java
+++ b/src/test/java/com/komentum/post/controller/DesignBoardControllerTest.java
@@ -77,25 +77,19 @@ public class DesignBoardControllerTest {
     boardDetailDataGenerator.deleteDesignBoards();
   }
 
-  private void assertDesignBoard(DesignBoardDetailDto response, String expectedTitle,
-      String expectedContent) {
-    // field assertion
-    assertThat(response)
-        .isNotNull();
-    assertThat(response.getTitle())
-        .isEqualTo(expectedTitle);
-    assertThat(response.getContent())
-        .isEqualTo(expectedContent);
+  private void assertDesignBoard(DesignBoardDetailDto response) {
     // DB assertion
-    DesignBoard savedData = designBoardRepository.findByPost_PostId(response.getPostId())
+    Post savedPost = postRepository.findById(response.getPostId())
         .orElse(null);
-    assertThat(savedData)
-        .isNotNull();
-    Post post = savedData.getPost();
-    assertThat(post.getTitle())
-        .isEqualTo(expectedTitle);
-    assertThat(post.getContent())
-        .isEqualTo(expectedContent);
+    DesignBoard savedDesignBoard = designBoardRepository.findByPost_PostId(response.getPostId())
+        .orElse(null);
+    assertThat(savedPost).isNotNull();
+    assertThat(savedDesignBoard).isNotNull();
+    // field assertion
+    assertThat(response).isNotNull();
+    assertThat(response.getTitle()).isEqualTo(savedPost.getTitle());
+    assertThat(response.getContent()).isEqualTo(savedPost.getContent());
+    assertThat(response.getPreviewImageUrl()).isNotEmpty();
   }
 
   @Test
@@ -108,6 +102,9 @@ public class DesignBoardControllerTest {
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
     params.add("size", Integer.toString(pageSize));
     params.add("page", Integer.toString(pageNumber));
+    // stub
+    Mockito.when(fileManager.resolveFilePath(anyString()))
+        .thenReturn(UUID.randomUUID().toString());
     // when
     List<DesignBoardPreviewDto> responses = mockMvcUtils.doAuthRequest(
         MockMvcRequestDto.<Void, List<DesignBoardPreviewDto>>builder()
@@ -133,6 +130,9 @@ public class DesignBoardControllerTest {
     String requestPath = String.format("/api/design-boards/%d",
         targetDesignBoard.getPost().getPostId());
     User client = boardDetailDataGenerator.getUsers().get(0);
+    // stub
+    Mockito.when(fileManager.resolveFilePath(anyString()))
+        .thenReturn(UUID.randomUUID().toString());
     // when
     DesignBoardDetailDto response = mockMvcUtils.doAuthRequest(
         MockMvcRequestDto.<Void, DesignBoardDetailDto>builder()
@@ -145,7 +145,38 @@ public class DesignBoardControllerTest {
             .build()
     );
     // then
-    assertDesignBoard(response, targetPost.getTitle(), targetPost.getContent());
+    assertDesignBoard(response);
+  }
+
+  @Test
+  @DisplayName("If a pinned post ID is provided, place that post at the top of the first page and return only design boards written by the same author.")
+  void findDesignBoardDetails_ifPinnedPostIdExists() throws Exception {
+    // given
+    DesignBoard targetDesignBoard = boardDetailDataGenerator.getDesignBoards().get(0);
+    Post pinnedPost = targetDesignBoard.getPost();
+    String requestPath = String.format("/api/design-boards/details?pinned_post_id=%d&page=0",
+        targetDesignBoard.getPost().getPostId());
+    User client = boardDetailDataGenerator.getUsers().get(0);
+    // stub
+    Mockito.when(fileManager.resolveFilePath(anyString()))
+        .thenReturn(UUID.randomUUID().toString());
+    // when
+    List<DesignBoardDetailDto> response = mockMvcUtils.doAuthRequest(
+        MockMvcRequestDto.<Void, List<DesignBoardDetailDto>>builder()
+            .mockMvc(mockMvc)
+            .httpMethod(HttpMethod.GET)
+            .path(requestPath)
+            .responseType(new TypeReference<>() {
+            })
+            .clientDto(TestClientDto.fromEntity(client))
+            .build()
+    );
+    // then
+    assertThat(response).isNotEmpty();
+    assertThat(response.get(0).getPostId()).isEqualTo(pinnedPost.getPostId());
+    for (DesignBoardDetailDto dto : response) {
+      assertDesignBoard(dto);
+    }
   }
 
   @Test
@@ -194,8 +225,8 @@ public class DesignBoardControllerTest {
     assertThat(response.getTags().stream().map(TagResponse::getTagName))
         .containsExactlyInAnyOrderElementsOf(tagNames);
     assertThat(response.getPreviewImageUrl())
-        .isEqualTo(expectedPreviewImageUrl);
-    assertDesignBoard(response, createDto.getTitle(), createDto.getContent());
+        .isEqualTo(List.of(expectedPreviewImageUrl));
+    assertDesignBoard(response);
   }
 
   @Test
@@ -245,7 +276,7 @@ public class DesignBoardControllerTest {
     // then : 필드 및 DB 검증
     assertThat(response.getTags().stream().map(TagResponse::getTagName))
         .containsExactlyInAnyOrderElementsOf(tagNames);
-    assertDesignBoard(response, expectedTitle, expectedContent);
+    assertDesignBoard(response);
   }
 
   @Test

--- a/src/test/java/com/komentum/post/controller/ThemeBoardControllerTest.java
+++ b/src/test/java/com/komentum/post/controller/ThemeBoardControllerTest.java
@@ -93,7 +93,7 @@ class ThemeBoardControllerTest {
     Post savedPost = postRepository.findById(detailDto.getPostId()).orElse(null);
     assertThat(savedPost).isNotNull();
     assertThat(detailDto.getThemeComponentId()).isNotNull();
-    assertThat(detailDto.getPreviewImageUrl()).isNotBlank();
+    assertThat(detailDto.getPreviewImageUrl()).isNotNull().isNotEmpty();
     assertThat(detailDto.getContent()).isEqualTo(savedPost.getContent());
     assertThat(detailDto.getTitle()).isEqualTo(savedPost.getTitle());
     assertThat(detailDto.getCreatedAt()).isNotBlank();
@@ -220,6 +220,35 @@ class ThemeBoardControllerTest {
   }
 
   @Test
+  @DisplayName("If a pinned post ID is provided, place that post at the top of the first page and return only theme boards written by the same author.")
+  void findThemeBoardDetails_ifPinnedPostIdExists() throws Exception {
+    // given
+    User client = boardDetailDataGenerator.getUsers().get(0);
+    Post pinnedPost = boardDetailDataGenerator.getThemeBoards().get(0).getPost();
+    // stub
+    Mockito.when(fileManager.resolveFilePath(anyString()))
+        .thenReturn(UUID.randomUUID().toString());
+    // when
+    List<ThemeBoardDetailDto> response = mockMvcUtils.doAuthRequest(
+        MockMvcRequestDto.<Void, List<ThemeBoardDetailDto>>builder()
+            .mockMvc(mockMvc)
+            .path(String.format("/api/theme-boards/details?pinned_post_id=%d&page=0",
+                pinnedPost.getPostId()))
+            .httpMethod(HttpMethod.GET)
+            .clientDto(TestClientDto.fromEntity(client))
+            .statusCode(200)
+            .responseType(new TypeReference<>() {
+            })
+            .build());
+    // then
+    assertThat(response).isNotEmpty();
+    assertThat(response.get(0).getPostId()).isEqualTo(pinnedPost.getPostId());
+    for (ThemeBoardDetailDto dto : response) {
+      assertThemeBoardDetail(dto);
+    }
+  }
+
+  @Test
   @DisplayName("테마 게시글 생성 성공 테스트")
   void createPost_success() throws Exception {
     // given
@@ -316,7 +345,7 @@ class ThemeBoardControllerTest {
     // then : 필드 검증
     assertThat(response.getTags().stream().map(TagResponse::getTagName))
         .containsExactlyInAnyOrderElementsOf(tagNames);
-    assertThat(response.getPreviewImageUrl()).isEqualTo(testPreviewImageUrl);
+    assertThat(response.getPreviewImageUrl()).isEqualTo(List.of(testPreviewImageUrl));
     assertThemeBoardDetail(response);
   }
 


### PR DESCRIPTION
## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용
- 테마 / 디자인 에셋 게시글 상세 조회 리스트 API 개발
  - pinned_post_id가 존재할 때
    - page 구분 없이 : pinned_post 작성자의 게시글만 제공
    - page=0일 때 : pinned_post를 응답 DTO 리스트 상단에 고정
    - page>0일 때 : pinned_post가 제외된 결과만 제공
  - pinned_post_id가 존재하지 않을 때
- 게시글 상세 조회 DTO에서 preview_image_url을 String[]으로 제공하도록 변경
- 게시글 상세 조회 DTO에서 게시글 작성자 프로필 이미지 URL ( profile_image )를 함께 제공하도록 변경

관련 이슈: #90 

## 테스트 결과
### 1. 통합 테스트 결과
<img width="1821" height="347" alt="image" src="https://github.com/user-attachments/assets/15c3ec52-48c9-49c1-9522-9f55ca4db9f1" />
<img width="1830" height="413" alt="image" src="https://github.com/user-attachments/assets/26d6b2c1-42da-40a6-bb16-90f6f3a6db3d" />

### 2. 수동 테스트 ( 테마 게시글 리스트 상세 조회 시 pinned_post_id가 존재하고, page=0 )
<img width="1394" height="703" alt="image" src="https://github.com/user-attachments/assets/26e35d5b-5732-4912-9c72-c7a37b3de554" />

### 3. 수동 테스트 ( 테마 게시글 리스트 상세 조회 시 pinned_post_id가 존재하고, page>0 )
<img width="1404" height="704" alt="image" src="https://github.com/user-attachments/assets/fe1e514e-731a-46d4-8262-26d3e9f50a3a" />

### 4. 수동 테스트 ( 테마 게시글 리스트 상세 조회 시 유효하지 않은 pinned_post_id가 존재 )
<img width="1403" height="401" alt="image" src="https://github.com/user-attachments/assets/3a8815d2-2a31-4f85-a4fc-2a701c735afd" />

### 5. 수동 테스트 ( 테마 게시글 리스트 상세 조회 시 pinned_post_id가 존재하지 않음 )
<img width="1398" height="696" alt="image" src="https://github.com/user-attachments/assets/5a391a23-684d-4bca-8f85-1c16bafaf6b6" />

### 6. 수동 테스트 ( 디자인 에셋 게시글 리스트 상세 조회 시 pinned_post_id가 존재하고, page=0 )
<img width="1404" height="703" alt="image" src="https://github.com/user-attachments/assets/2cd61dbe-aa99-4c92-a85a-3deee29be85f" />

### 7. 수동 테스트 ( 디자인 에셋 게시글 리스트 상세 조회 시 pinned_post_id가 존재하고, page>0 )
<img width="1396" height="702" alt="image" src="https://github.com/user-attachments/assets/e7b5fec9-6762-4c0f-b57d-6e954c3a21b2" />

### 8. 수동 테스트 ( 디자인 에셋 게시글 리스트 상세 조회 시 유효하지 않은 pinned_post_id가 존재 )
<img width="1406" height="403" alt="image" src="https://github.com/user-attachments/assets/2633fa4e-f45a-462b-aa33-41a10312c9e0" />

### 9. 수동 테스트 ( 디자인 에셋 게시글 리스트 상세 조회 시 pinned_post_id가 존재하지 않음 )
<img width="1407" height="705" alt="image" src="https://github.com/user-attachments/assets/12e93bf9-5176-41a7-beab-d1f93bd64b65" />

## PR 체크리스트
- [x] 커밋 메시지가 가이드라인을 따르는가
- [x] 테스트 코드를 모두 통과하였는가
- [x] 관련 이슈를 연결하였는가
