### PR TITLE
Feat/#92 사용자 북마크/업로드 게시글 조회 기능 개선 및 내 커스텀 요소 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/komentum/catalog/controller/ComponentCatalogController.java
+++ b/src/main/java/com/komentum/catalog/controller/ComponentCatalogController.java
@@ -1,0 +1,32 @@
+package com.komentum.catalog.controller;
+
+import com.komentum.catalog.dto.ComponentCatalogResponse;
+import com.komentum.catalog.service.ComponentCatalogService;
+import com.komentum.global.dto.CustomUserDetails;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ComponentCatalogController {
+
+  private final ComponentCatalogService componentCatalogService;
+
+  @GetMapping("/users/me/custom-components")
+  public ResponseEntity<List<ComponentCatalogResponse>> findCustomComponents(
+      @PageableDefault(size = 20) @ParameterObject Pageable pageable,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    return ResponseEntity.ok(
+        componentCatalogService.findComponentCatalogs(pageable, userDetails.getUsername()));
+  }
+}

--- a/src/main/java/com/komentum/catalog/controller/ComponentCatalogController.java
+++ b/src/main/java/com/komentum/catalog/controller/ComponentCatalogController.java
@@ -3,6 +3,7 @@ package com.komentum.catalog.controller;
 import com.komentum.catalog.dto.ComponentCatalogResponse;
 import com.komentum.catalog.service.ComponentCatalogService;
 import com.komentum.global.dto.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -22,6 +23,7 @@ public class ComponentCatalogController {
   private final ComponentCatalogService componentCatalogService;
 
   @GetMapping("/users/me/custom-components")
+  @Operation(summary = "현재 사용자가 생성한 디자인 에셋과 테마 목록을 생성일 기준 내림차순으로 페이징 조회한다")
   public ResponseEntity<List<ComponentCatalogResponse>> findCustomComponents(
       @PageableDefault(size = 20) @ParameterObject Pageable pageable,
       @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/komentum/catalog/dto/ComponentCatalogResponse.java
+++ b/src/main/java/com/komentum/catalog/dto/ComponentCatalogResponse.java
@@ -1,5 +1,6 @@
 package com.komentum.catalog.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -7,11 +8,16 @@ import lombok.Data;
 @Data
 @Builder
 @AllArgsConstructor
+@Schema(description = "테마 + 디자인 에셋 복합 조회 응답 DTO")
 public class ComponentCatalogResponse {
 
+  @Schema(description = "데이터 종류 ( THEME | DESIGN )", example = "THEME | DESIGN")
   private ComponentType componentType;
+  @Schema(description = "테마 혹은 디자인 에셋의 식별자")
   private Integer componentId;
+  @Schema(description = "테마 혹은 디자인 에셋의 대표 이미지")
   private String previewImageUrl;
+  @Schema(description = "테마 혹은 디자인 에셋의 생성 시간")
   private String createdAt;
 
   public static ComponentCatalogResponse of(ComponentSummary summary) {

--- a/src/main/java/com/komentum/catalog/dto/ComponentCatalogResponse.java
+++ b/src/main/java/com/komentum/catalog/dto/ComponentCatalogResponse.java
@@ -1,0 +1,25 @@
+package com.komentum.catalog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ComponentCatalogResponse {
+
+  private ComponentType componentType;
+  private Integer componentId;
+  private String previewImageUrl;
+  private String createdAt;
+
+  public static ComponentCatalogResponse of(ComponentSummary summary) {
+    return ComponentCatalogResponse.builder()
+        .componentType(summary.getType())
+        .componentId(summary.getId())
+        .previewImageUrl(summary.getPreviewImageUrl())
+        .createdAt(summary.getCreatedAt().toString())
+        .build();
+  }
+}

--- a/src/main/java/com/komentum/catalog/dto/ComponentCatalogResponse.java
+++ b/src/main/java/com/komentum/catalog/dto/ComponentCatalogResponse.java
@@ -3,9 +3,11 @@ package com.komentum.catalog.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @Schema(description = "테마 + 디자인 에셋 복합 조회 응답 DTO")

--- a/src/main/java/com/komentum/catalog/dto/ComponentSummary.java
+++ b/src/main/java/com/komentum/catalog/dto/ComponentSummary.java
@@ -1,0 +1,21 @@
+package com.komentum.catalog.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ComponentSummary {
+
+  private Integer id;
+  private ComponentType type;
+  private String previewImageUrl;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/komentum/catalog/dto/ComponentType.java
+++ b/src/main/java/com/komentum/catalog/dto/ComponentType.java
@@ -1,0 +1,15 @@
+package com.komentum.catalog.dto;
+
+public enum ComponentType {
+  THEME,
+  DESIGN;
+
+  public static ComponentType fromString(String type) {
+    for (ComponentType componentType : ComponentType.values()) {
+      if (componentType.name().equalsIgnoreCase(type)) {
+        return componentType;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepository.java
+++ b/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepository.java
@@ -1,0 +1,11 @@
+package com.komentum.catalog.repository;
+
+import com.komentum.catalog.dto.ComponentSummary;
+import com.komentum.user.domain.User;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface ComponentCatalogRepository {
+
+  public List<ComponentSummary> findComponentSummaryByClient(Pageable pageable, User client);
+}

--- a/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepository.java
+++ b/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface ComponentCatalogRepository {
 
-  public List<ComponentSummary> findComponentSummaryByClient(Pageable pageable, User client);
+  public List<ComponentSummary> findComponentSummaryByClient(Pageable pageable, User client,
+      String clientEmail);
 }

--- a/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepositoryImpl.java
+++ b/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepositoryImpl.java
@@ -19,7 +19,8 @@ public class ComponentCatalogRepositoryImpl implements ComponentCatalogRepositor
   private final EntityManager em;
 
   @Override
-  public List<ComponentSummary> findComponentSummaryByClient(Pageable pageable, User client) {
+  public List<ComponentSummary> findComponentSummaryByClient(Pageable pageable, User client,
+      String clientEmail) {
     String query = """
         SELECT id, type, preview_image_url, created_at
         FROM (
@@ -29,8 +30,7 @@ public class ComponentCatalogRepositoryImpl implements ComponentCatalogRepositor
             NULL as preview_image_url,
             tc.created_at as created_at
           FROM theme_component tc
-          JOIN "user" u ON tc.user_email = u.user_email
-          WHERE u.user_id = :userId
+          WHERE tc.user_email = :clientEmail
           UNION ALL
           SELECT
             dc.design_component_id as id,
@@ -49,6 +49,7 @@ public class ComponentCatalogRepositoryImpl implements ComponentCatalogRepositor
         .setParameter("limit", pageable.getPageSize())
         .setParameter("offset", pageable.getOffset())
         .setParameter("userId", client.getUserId())
+        .setParameter("clientEmail", clientEmail)
         .getResultList();
     List<ComponentSummary> summaries = rows.stream()
         .map(row -> new ComponentSummary(

--- a/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepositoryImpl.java
+++ b/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.komentum.user.domain.User;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -44,20 +45,42 @@ public class ComponentCatalogRepositoryImpl implements ComponentCatalogRepositor
         LIMIT :limit
         OFFSET :offset
         """;
-
+    // execute query and retrieve results
     List<Object[]> rows = em.createNativeQuery(query)
         .setParameter("limit", pageable.getPageSize())
         .setParameter("offset", pageable.getOffset())
         .setParameter("userId", client.getUserId())
         .setParameter("clientEmail", clientEmail)
         .getResultList();
+    // convert to ComponentSummary
     List<ComponentSummary> summaries = rows.stream()
-        .map(row -> new ComponentSummary(
-            ((Number) row[0]).intValue(),
-            ComponentType.fromString((String) row[1]),
-            (String) row[2],
-            ((Timestamp) row[3]).toLocalDateTime()
-        ))
+        .map(row -> {
+          // id (not null)
+          if (row[0] == null) {
+            throw new IllegalStateException(
+                "ComponentSummary mapping failed: id(row[0]) is null");
+          }
+          int id = ((Number) row[0]).intValue();
+          // 2. type (not null)
+          if (row[1] == null) {
+            throw new IllegalStateException(
+                "ComponentSummary mapping failed: type(row[1]) is null");
+          }
+          ComponentType type = ComponentType.fromString((String) row[1]);
+          if (type == null) {
+            throw new IllegalArgumentException(
+                "ComponentSummary mapping failed: Unknown ComponentType: " + row[1]);
+          }
+          // 3. previewImageUrl (nullable)
+          String previewImageUrl = (String) row[2];
+          // 4. createdAt (not null)
+          if (row[3] == null) {
+            throw new IllegalStateException(
+                "ComponentSummary mapping failed: createdAt(row[3]) is null");
+          }
+          LocalDateTime createdAt = ((Timestamp) row[3]).toLocalDateTime();
+          return new ComponentSummary(id, type, previewImageUrl, createdAt);
+        })
         .toList();
     return summaries;
   }

--- a/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepositoryImpl.java
+++ b/src/main/java/com/komentum/catalog/repository/ComponentCatalogRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.komentum.catalog.repository;
+
+import com.komentum.catalog.dto.ComponentSummary;
+import com.komentum.catalog.dto.ComponentType;
+import com.komentum.user.domain.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.sql.Timestamp;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ComponentCatalogRepositoryImpl implements ComponentCatalogRepository {
+
+  @PersistenceContext
+  private final EntityManager em;
+
+  @Override
+  public List<ComponentSummary> findComponentSummaryByClient(Pageable pageable, User client) {
+    String query = """
+        SELECT id, type, preview_image_url, created_at
+        FROM (
+          SELECT
+            tc.theme_component_id as id,
+            'THEME' as type,
+            NULL as preview_image_url,
+            tc.created_at as created_at
+          FROM theme_component tc
+          JOIN "user" u ON tc.user_email = u.user_email
+          WHERE u.user_id = :userId
+          UNION ALL
+          SELECT
+            dc.design_component_id as id,
+            'DESIGN' as type,
+            dc.image_url as preview_image_url,
+            dc.created_at as created_at
+          FROM design_component dc
+          WHERE dc.user_id = :userId
+        ) combined
+        ORDER BY created_at DESC
+        LIMIT :limit
+        OFFSET :offset
+        """;
+
+    List<Object[]> rows = em.createNativeQuery(query)
+        .setParameter("limit", pageable.getPageSize())
+        .setParameter("offset", pageable.getOffset())
+        .setParameter("userId", client.getUserId())
+        .getResultList();
+    List<ComponentSummary> summaries = rows.stream()
+        .map(row -> new ComponentSummary(
+            ((Number) row[0]).intValue(),
+            ComponentType.fromString((String) row[1]),
+            (String) row[2],
+            ((Timestamp) row[3]).toLocalDateTime()
+        ))
+        .toList();
+    return summaries;
+  }
+}

--- a/src/main/java/com/komentum/catalog/service/ComponentCatalogService.java
+++ b/src/main/java/com/komentum/catalog/service/ComponentCatalogService.java
@@ -27,7 +27,8 @@ public class ComponentCatalogService {
       String userIdentifier) {
     User client = userEntityFinder.findUserEntity(userIdentifier);
     List<ComponentSummary> summaries =
-        componentCatalogRepository.findComponentSummaryByClient(pageable, client);
+        componentCatalogRepository.findComponentSummaryByClient(pageable, client,
+            client.getUserEmail());
     // find theme preview image
     Map<Integer, String> themePreviewImageMap =
         themeImageService.findThemePreviewImages(

--- a/src/main/java/com/komentum/catalog/service/ComponentCatalogService.java
+++ b/src/main/java/com/komentum/catalog/service/ComponentCatalogService.java
@@ -1,0 +1,50 @@
+package com.komentum.catalog.service;
+
+import com.komentum.catalog.dto.ComponentCatalogResponse;
+import com.komentum.catalog.dto.ComponentSummary;
+import com.komentum.catalog.dto.ComponentType;
+import com.komentum.catalog.repository.ComponentCatalogRepository;
+import com.komentum.theme.theme.service.ThemeImageService;
+import com.komentum.user.domain.User;
+import com.komentum.user.service.UserEntityFinder;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ComponentCatalogService {
+
+  private final ComponentCatalogRepository componentCatalogRepository;
+  private final ThemeImageService themeImageService;
+  private final UserEntityFinder userEntityFinder;
+
+  @Transactional(readOnly = true)
+  public List<ComponentCatalogResponse> findComponentCatalogs(Pageable pageable,
+      String userIdentifier) {
+    User client = userEntityFinder.findUserEntity(userIdentifier);
+    List<ComponentSummary> summaries =
+        componentCatalogRepository.findComponentSummaryByClient(pageable, client);
+    // find theme preview image
+    Map<Integer, String> themePreviewImageMap =
+        themeImageService.findThemePreviewImages(
+            summaries.stream()
+                .filter(s -> s.getType() == ComponentType.THEME)
+                .map(ComponentSummary::getId)
+                .toList()
+        );
+    // convert to response
+    return summaries.stream()
+        .map(s -> {
+          String preview = s.getType() == ComponentType.THEME
+              ? themePreviewImageMap.get(s.getId())
+              : s.getPreviewImageUrl();
+          s.setPreviewImageUrl(preview);
+          return ComponentCatalogResponse.of(s);
+        })
+        .toList();
+  }
+}

--- a/src/main/java/com/komentum/post/consts/ThemeBoardConsts.java
+++ b/src/main/java/com/komentum/post/consts/ThemeBoardConsts.java
@@ -3,4 +3,5 @@ package com.komentum.post.consts;
 public final class ThemeBoardConsts {
 
   public static final String DEFAULT_COMPONENT_TYPE_NAME = "theme_profile_01_image.png";
+  public static final String DEFAULT_COMPONENT_TYPE_PATH = "res/drawable-xxhdpi/theme_profile_01_image.png";
 }

--- a/src/main/java/com/komentum/post/controller/UserPostController.java
+++ b/src/main/java/com/komentum/post/controller/UserPostController.java
@@ -7,6 +7,9 @@ import com.komentum.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,9 +27,11 @@ public class UserPostController {
   // user post dto 리스트 -> 커스텀 응답
   @GetMapping("/me/upload-posts")
   @Operation(summary = "현재 인증된 사용자가 업로드/소유한 게시글 목록을 조회한다")
-  public ResponseEntity<List<UserPostListResponseDto>> findUserPostList(@AuthenticationPrincipal
-  CustomUserDetails userDetails) {
-    return ResponseEntity.ok(postManagementFacade.findMyPostsByUser(userDetails.getUsername()));
+  public ResponseEntity<List<UserPostListResponseDto>> findUserPostList(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PageableDefault(size = 20) @ParameterObject Pageable pageable) {
+    return ResponseEntity.ok(
+        postManagementFacade.findMyPostsByUser(userDetails.getUsername(), pageable));
   }
 
   /**
@@ -35,18 +40,19 @@ public class UserPostController {
   @GetMapping("/me/bookmarked-posts")
   @Operation(summary = "현재 인증된 사용자가 북마크에 추가한 게시글 목록을 조회한다")
   public ResponseEntity<List<UserPostListResponseDto>> findSavedPostList(
-      @AuthenticationPrincipal CustomUserDetails userDetails
-  ) {
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PageableDefault(size = 20) @ParameterObject Pageable pageable) {
     return ResponseEntity.ok(
-        postManagementFacade.findUserSavedPostsByCategory(userDetails.getUsername()));
+        postManagementFacade.findUserSavedPostsByCategory(userDetails.getUsername(), pageable));
   }
 
   @GetMapping("/me/preferred-posts")
   @Operation(summary = "현재 인증된 사용자가 좋아요를 누른 게시글 목록을 조회한다")
   public ResponseEntity<List<UserPostListResponseDto>> findPreferredPostList(
-      @AuthenticationPrincipal CustomUserDetails userDetails
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PageableDefault(size = 20) @ParameterObject Pageable pageable
   ) {
     return ResponseEntity.ok(
-        postManagementFacade.findUserPreferredPosts(userDetails.getUsername()));
+        postManagementFacade.findUserPreferredPosts(userDetails.getUsername(), pageable));
   }
 }

--- a/src/main/java/com/komentum/post/dto/PostDto.java
+++ b/src/main/java/com/komentum/post/dto/PostDto.java
@@ -2,10 +2,12 @@ package com.komentum.post.dto;
 
 import com.komentum.post.domain.Post;
 import com.komentum.post.domain.enums.PostType;
+import com.komentum.post.dto.query.PostQuery;
 import com.komentum.post.facade.BoardManagementHelper;
 import com.komentum.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -46,8 +48,8 @@ public class PostDto {
 
     @Schema(description = "게시글 ID")
     Long postId;
-    @Schema(description = "게시글 대표 이미지 URL", example = "https://sample.com")
-    String previewImageUrl;
+    @Schema(description = "게시글 대표 이미지 URL 목록", example = "[https://sample.com, ... ]")
+    List<String> previewImageUrl;
     @Schema(description = "게시글 생성일")
     LocalDateTime createdAt;
     @Schema(description = "게시글 갱신일")
@@ -58,18 +60,34 @@ public class PostDto {
     String authorName;
     @Schema(description = "게시글 작성자 프로필 이미지 URL")
     String authorProfileImageUrl;
+    @Schema(description = "게시글 좋아요 수")
+    Long prefers;
+    @Schema(description = "게시글 댓글 수")
+    Long comments;
+    @Schema(description = "현재 사용자의 북마크 여부")
+    Boolean bookmarked;
+    @Schema(description = "현재 사용자의 좋아요 여부")
+    Boolean preferred;
 
-    public static UserPostListResponseDto from(Post post,
+    public static UserPostListResponseDto from(PostQuery.Detail postDetail,
         BoardManagementHelper boardManagementHelper) {
-      User author = post.getUser();
+      User author = postDetail.getPost().getUser();
+      Post post = postDetail.getPost();
+      String previewImageUrl = boardManagementHelper.findPreviewImageUrl(
+          post.getPreviewImageName());
+      List<String> previewImageUrls = previewImageUrl == null ? null : List.of(previewImageUrl);
       return UserPostListResponseDto.builder()
           .postId(post.getPostId())
-          .previewImageUrl(boardManagementHelper.findPreviewImageUrl(post.getPreviewImageName()))
+          .previewImageUrl(previewImageUrls)
           .createdAt(post.getCreatedAt())
           .updatedAt(post.getUpdatedAt())
           .postType(post.getPostType())
           .authorName(author.getName())
           .authorProfileImageUrl(author.getProfileImg())
+          .prefers(postDetail.getPrefers())
+          .comments(postDetail.getComments())
+          .preferred(postDetail.getPreferred())
+          .bookmarked(postDetail.getBookmarked())
           .build();
     }
   }

--- a/src/main/java/com/komentum/post/dto/PostDto.java
+++ b/src/main/java/com/komentum/post/dto/PostDto.java
@@ -75,7 +75,8 @@ public class PostDto {
       Post post = postDetail.getPost();
       String previewImageUrl = boardManagementHelper.findPreviewImageUrl(
           post.getPreviewImageName());
-      List<String> previewImageUrls = previewImageUrl == null ? null : List.of(previewImageUrl);
+      List<String> previewImageUrls =
+          previewImageUrl == null ? List.of() : List.of(previewImageUrl);
       return UserPostListResponseDto.builder()
           .postId(post.getPostId())
           .previewImageUrl(previewImageUrls)

--- a/src/main/java/com/komentum/post/dto/query/PostQuery.java
+++ b/src/main/java/com/komentum/post/dto/query/PostQuery.java
@@ -1,0 +1,23 @@
+package com.komentum.post.dto.query;
+
+import com.komentum.post.domain.Post;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+public class PostQuery {
+
+  @Getter
+  @Setter
+  @Builder
+  @AllArgsConstructor
+  public static class Detail {
+
+    private Post post;
+    private Long prefers;
+    private Long comments;
+    private Boolean preferred;
+    private Boolean bookmarked;
+  }
+}

--- a/src/main/java/com/komentum/post/facade/PostManagementFacade.java
+++ b/src/main/java/com/komentum/post/facade/PostManagementFacade.java
@@ -6,6 +6,7 @@ import com.komentum.user.domain.User;
 import com.komentum.user.service.UserEntityFinder;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,25 +24,26 @@ public class PostManagementFacade {
    * @return UserPostListResponseDto 목록
    */
   @Transactional
-  public List<UserPostListResponseDto> findUserSavedPostsByCategory(String clientId) {
+  public List<UserPostListResponseDto> findUserSavedPostsByCategory(String clientId,
+      Pageable pageable) {
     User client = userEntityFinder.findUserEntity(clientId);
-    return postService.findUserSavedPosts(client).stream()
+    return postService.findUserSavedPosts(client, pageable).stream()
         .map(p -> UserPostListResponseDto.from(p, boardManagementHelper))
         .toList();
   }
 
   @Transactional
-  public List<UserPostListResponseDto> findUserPreferredPosts(String clientId) {
+  public List<UserPostListResponseDto> findUserPreferredPosts(String clientId, Pageable pageable) {
     User client = userEntityFinder.findUserEntity(clientId);
-    return postService.findUserPreferredPosts(client).stream()
+    return postService.findUserPreferredPosts(client, pageable).stream()
         .map(p -> UserPostListResponseDto.from(p, boardManagementHelper))
         .toList();
   }
 
   @Transactional
-  public List<UserPostListResponseDto> findMyPostsByUser(String clientId) {
+  public List<UserPostListResponseDto> findMyPostsByUser(String clientId, Pageable pageable) {
     User client = userEntityFinder.findUserEntity(clientId);
-    return postService.findUserPostList(client).stream()
+    return postService.findUserPostList(client, pageable).stream()
         .map(p -> UserPostListResponseDto.from(p, boardManagementHelper))
         .toList();
   }

--- a/src/main/java/com/komentum/post/repository/PostRepositorySupport.java
+++ b/src/main/java/com/komentum/post/repository/PostRepositorySupport.java
@@ -87,7 +87,7 @@ public class PostRepositorySupport {
    * @param client 카테고리에 게시글을 저장한 User 엔티티
    * @return 카테고리에 저장된 게시글 목록
    * */
-  public List<PostQuery.Detail> findBookmarkedPostsByUser(User client) {
+  public List<PostQuery.Detail> findBookmarkedPostsByUser(User client, Pageable pageable) {
     QPost post = QPost.post;
     QCategory category = QCategory.category;
     QCategoryPost categoryPost = QCategoryPost.categoryPost;
@@ -104,13 +104,15 @@ public class PostRepositorySupport {
         .join(categoryPost.category, category)
         .join(post.user, user).fetchJoin()
         .where(category.owner.eq(client).and(category.categoryType.eq(CategoryType.BOOKMARK)))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
         .fetch();
   }
 
   /**
    * 사용자가 좋아요를 누른 게시글 목록 조회
    * */
-  public List<PostQuery.Detail> findUserPreferredPosts(User client) {
+  public List<PostQuery.Detail> findUserPreferredPosts(User client, Pageable pageable) {
     QPost post = QPost.post;
     QPrefer prefer = QPrefer.prefer;
     QUser user = QUser.user;
@@ -125,13 +127,15 @@ public class PostRepositorySupport {
         .join(prefer.post, post)
         .join(post.user, user).fetchJoin()
         .where(prefer.user.eq(client))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
         .fetch();
   }
 
   /**
    * 사용자가 소융한 게시글 목록 조회
    * */
-  public List<PostQuery.Detail> findMyPostsByUser(User client) {
+  public List<PostQuery.Detail> findMyPostsByUser(User client, Pageable pageable) {
     QPost post = QPost.post;
     QUser user = QUser.user;
     return queryFactory.select(Projections.constructor(PostQuery.Detail.class,
@@ -144,6 +148,8 @@ public class PostRepositorySupport {
         .from(post)
         .join(post.user, user).fetchJoin()
         .where(post.user.eq(client))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
         .fetch();
   }
 

--- a/src/main/java/com/komentum/post/repository/PostRepositorySupport.java
+++ b/src/main/java/com/komentum/post/repository/PostRepositorySupport.java
@@ -3,15 +3,19 @@ package com.komentum.post.repository;
 import com.komentum.post.domain.Post;
 import com.komentum.post.domain.QCategory;
 import com.komentum.post.domain.QCategoryPost;
+import com.komentum.post.domain.QComment;
 import com.komentum.post.domain.QPost;
 import com.komentum.post.domain.QPrefer;
 import com.komentum.post.dto.PostSummary;
+import com.komentum.post.dto.query.PostQuery;
 import com.komentum.post.service.enums.CategoryType;
 import com.komentum.theme.exception.ResourceNotFoundException;
 import com.komentum.user.domain.QUser;
 import com.komentum.user.domain.User;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Map;
@@ -83,12 +87,18 @@ public class PostRepositorySupport {
    * @param client 카테고리에 게시글을 저장한 User 엔티티
    * @return 카테고리에 저장된 게시글 목록
    * */
-  public List<Post> findBookmarkedPostsByUser(User client) {
+  public List<PostQuery.Detail> findBookmarkedPostsByUser(User client) {
     QPost post = QPost.post;
     QCategory category = QCategory.category;
     QCategoryPost categoryPost = QCategoryPost.categoryPost;
     QUser user = QUser.user;
-    return queryFactory.select(post)
+    return queryFactory.select(Projections.constructor(PostQuery.Detail.class,
+            post,
+            countPrefers(post),
+            countComments(post),
+            isLiked(post, client),
+            isBookmarked(post, client)
+        ))
         .from(categoryPost)
         .join(categoryPost.post, post)
         .join(categoryPost.category, category)
@@ -100,11 +110,17 @@ public class PostRepositorySupport {
   /**
    * 사용자가 좋아요를 누른 게시글 목록 조회
    * */
-  public List<Post> findUserPreferredPosts(User client) {
+  public List<PostQuery.Detail> findUserPreferredPosts(User client) {
     QPost post = QPost.post;
     QPrefer prefer = QPrefer.prefer;
     QUser user = QUser.user;
-    return queryFactory.select(post)
+    return queryFactory.select(Projections.constructor(PostQuery.Detail.class,
+            post,
+            countPrefers(post),
+            countComments(post),
+            isLiked(post, client),
+            isBookmarked(post, client)
+        ))
         .from(prefer)
         .join(prefer.post, post)
         .join(post.user, user).fetchJoin()
@@ -115,10 +131,16 @@ public class PostRepositorySupport {
   /**
    * 사용자가 소융한 게시글 목록 조회
    * */
-  public List<Post> findMyPostsByUser(User client) {
+  public List<PostQuery.Detail> findMyPostsByUser(User client) {
     QPost post = QPost.post;
     QUser user = QUser.user;
-    return queryFactory.select(post)
+    return queryFactory.select(Projections.constructor(PostQuery.Detail.class,
+            post,
+            countPrefers(post),
+            countComments(post),
+            isLiked(post, client),
+            isBookmarked(post, client)
+        ))
         .from(post)
         .join(post.user, user).fetchJoin()
         .where(post.user.eq(client))
@@ -148,5 +170,19 @@ public class PostRepositorySupport {
             categoryPost.category.owner.eq(user)
         )
         .exists();
+  }
+
+  public JPQLQuery<Long> countPrefers(QPost post) {
+    QPrefer prefer = QPrefer.prefer;
+    return JPAExpressions.select(prefer.count())
+        .from(prefer)
+        .where(prefer.post.eq(post));
+  }
+
+  public JPQLQuery<Long> countComments(QPost post) {
+    QComment comment = QComment.comment;
+    return JPAExpressions.select(comment.count())
+        .from(comment)
+        .where(comment.post.eq(post));
   }
 }

--- a/src/main/java/com/komentum/post/service/PostService.java
+++ b/src/main/java/com/komentum/post/service/PostService.java
@@ -6,6 +6,7 @@ import com.komentum.post.domain.enums.PostType;
 import com.komentum.post.domain.policy.PostPolicy;
 import com.komentum.post.dto.PostDto.PostCreateDto;
 import com.komentum.post.dto.PostDto.PostUpdateDto;
+import com.komentum.post.dto.query.PostQuery;
 import com.komentum.post.repository.PostRepository;
 import com.komentum.post.repository.PostRepositorySupport;
 import com.komentum.user.domain.User;
@@ -109,7 +110,7 @@ public class PostService {
    *
    */
   @Transactional(readOnly = true)
-  public List<Post> findUserPostList(User user) {
+  public List<PostQuery.Detail> findUserPostList(User user) {
     return postRepositorySupport.findMyPostsByUser(user);
   }
 
@@ -121,12 +122,12 @@ public class PostService {
 
   // 사용자가 카테고리에 저장한 게시글 목록 조회
   @Transactional(readOnly = true)
-  public List<Post> findUserSavedPosts(User user) {
+  public List<PostQuery.Detail> findUserSavedPosts(User user) {
     return postRepositorySupport.findBookmarkedPostsByUser(user);
   }
 
   @Transactional(readOnly = true)
-  public List<Post> findUserPreferredPosts(User user) {
+  public List<PostQuery.Detail> findUserPreferredPosts(User user) {
     return postRepositorySupport.findUserPreferredPosts(user);
   }
 }

--- a/src/main/java/com/komentum/post/service/PostService.java
+++ b/src/main/java/com/komentum/post/service/PostService.java
@@ -13,6 +13,7 @@ import com.komentum.user.domain.User;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -110,8 +111,8 @@ public class PostService {
    *
    */
   @Transactional(readOnly = true)
-  public List<PostQuery.Detail> findUserPostList(User user) {
-    return postRepositorySupport.findMyPostsByUser(user);
+  public List<PostQuery.Detail> findUserPostList(User user, Pageable pageable) {
+    return postRepositorySupport.findMyPostsByUser(user, pageable);
   }
 
   // 업로드 수 count 반환 메서드
@@ -122,12 +123,12 @@ public class PostService {
 
   // 사용자가 카테고리에 저장한 게시글 목록 조회
   @Transactional(readOnly = true)
-  public List<PostQuery.Detail> findUserSavedPosts(User user) {
-    return postRepositorySupport.findBookmarkedPostsByUser(user);
+  public List<PostQuery.Detail> findUserSavedPosts(User user, Pageable pageable) {
+    return postRepositorySupport.findBookmarkedPostsByUser(user, pageable);
   }
 
   @Transactional(readOnly = true)
-  public List<PostQuery.Detail> findUserPreferredPosts(User user) {
-    return postRepositorySupport.findUserPreferredPosts(user);
+  public List<PostQuery.Detail> findUserPreferredPosts(User user, Pageable pageable) {
+    return postRepositorySupport.findUserPreferredPosts(user, pageable);
   }
 }

--- a/src/main/java/com/komentum/theme/theme/domain/ThemeComponent.java
+++ b/src/main/java/com/komentum/theme/theme/domain/ThemeComponent.java
@@ -3,12 +3,13 @@ package com.komentum.theme.theme.domain;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.AccessLevel;
@@ -19,6 +20,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.BatchSize;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Slf4j
 @Entity
@@ -28,6 +32,7 @@ import org.hibernate.annotations.BatchSize;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class ThemeComponent {
 
   @Id
@@ -52,6 +57,12 @@ public class ThemeComponent {
 
   @Column(name = "is_public")
   private Boolean isPublic;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
 
   @Builder.Default
   @Setter(AccessLevel.NONE)

--- a/src/main/java/com/komentum/theme/theme/repository/ThemeImageRepository.java
+++ b/src/main/java/com/komentum/theme/theme/repository/ThemeImageRepository.java
@@ -25,4 +25,16 @@ public interface ThemeImageRepository extends JpaRepository<ThemeImage, ThemeIma
   List<ThemeImage> findByThemeComponentAndComponentType_ComponentName(
       ThemeComponent themeComponent,
       String componentTypeComponentName);
+
+  @Query("SELECT ti FROM ThemeImage ti "
+      + "JOIN FETCH ti.themeComponent tc "
+      + "JOIN FETCH ti.componentType ct "
+      + "JOIN FETCH ti.designComponent dc "
+      + "WHERE tc.themeComponentId IN :themeComponentIds "
+      + "AND ct.componentName = :componentTypeName "
+      + "AND ct.componentPath = :componentTypePath")
+  List<ThemeImage> fetchJoinByThemeComponentAndComponentInfo(
+      List<Integer> themeComponentIds,
+      String componentTypeName,
+      String componentTypePath);
 }

--- a/src/main/java/com/komentum/theme/theme/service/ThemeImageService.java
+++ b/src/main/java/com/komentum/theme/theme/service/ThemeImageService.java
@@ -1,10 +1,13 @@
 package com.komentum.theme.theme.service;
 
+import com.komentum.post.consts.ThemeBoardConsts;
 import com.komentum.theme.theme.domain.ThemeComponent;
 import com.komentum.theme.theme.domain.ThemeImage;
 import com.komentum.theme.theme.repository.ThemeImageRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,5 +30,20 @@ public class ThemeImageService {
           "ThemeImage not found for componentTypeName : " + componentTypeName);
     }
     return themeImages.get(0);
+  }
+
+  @Transactional(readOnly = true)
+  public Map<Integer, String> findThemePreviewImages(List<Integer> themeComponentIds) {
+    List<ThemeImage> themeImageList = themeImageRepository.fetchJoinByThemeComponentAndComponentInfo(
+        themeComponentIds,
+        ThemeBoardConsts.DEFAULT_COMPONENT_TYPE_NAME,
+        ThemeBoardConsts.DEFAULT_COMPONENT_TYPE_PATH
+    );
+    return themeImageList.stream()
+        .collect(Collectors.toMap(
+            ti -> ti.getThemeComponent().getThemeComponentId(),
+            ti -> ti.getDesignComponent().getImageUrl(),
+            (v1, v2) -> v1
+        ));
   }
 }

--- a/src/test/java/com/komentum/catalog/controller/ComponentCatalogControllerTest.java
+++ b/src/test/java/com/komentum/catalog/controller/ComponentCatalogControllerTest.java
@@ -1,0 +1,106 @@
+package com.komentum.catalog.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.komentum.catalog.dto.ComponentCatalogResponse;
+import com.komentum.catalog.dto.ComponentType;
+import com.komentum.global.utils.FileManager;
+import com.komentum.test.MockMvcUtils;
+import com.komentum.test.config.EnableTestProfile;
+import com.komentum.test.data.TestDataRemover;
+import com.komentum.test.data.scenario.DesignComponentScenarioSupport;
+import com.komentum.test.data.scenario.ThemeComponentScenarioSupport;
+import com.komentum.test.data.scenario.UserScenarioSupport;
+import com.komentum.test.dto.MockMvcRequestDto;
+import com.komentum.test.dto.TestClientDto;
+import com.komentum.test.dto.TestParams;
+import com.komentum.user.domain.User;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.MultiValueMap;
+
+@SpringBootTest
+@EnableTestProfile
+@AutoConfigureMockMvc
+class ComponentCatalogControllerTest {
+
+  @Autowired
+  private TestDataRemover testDataRemover;
+
+  @Autowired
+  private UserScenarioSupport userScenarioSupport;
+
+  @Autowired
+  private DesignComponentScenarioSupport designComponentScenarioSupport;
+
+  @Autowired
+  private ThemeComponentScenarioSupport themeComponentScenarioSupport;
+
+  @Autowired
+  private MockMvcUtils mockMvcUtils;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private FileManager fileManager;
+
+  @AfterEach
+  public void tearDown() {
+    testDataRemover.deleteAll();
+  }
+
+  void assertUserPostListResponseDto(ComponentCatalogResponse responseDto) {
+    assertThat(responseDto.getComponentId()).isNotNull();
+    assertThat(responseDto.getComponentType()).isIn(ComponentType.DESIGN, ComponentType.THEME);
+    assertThat(responseDto.getPreviewImageUrl()).isNotBlank();
+  }
+
+  @Test
+  @DisplayName("when send request, return user's theme and design components order by created date desc")
+  void findCustomComponents_success() throws Exception {
+    // stub
+    BDDMockito.given(fileManager.resolveFilePath(BDDMockito.anyString()))
+        .willReturn("http://mocked-url/1234567890");
+    // given: 사용자마다 3개의 design component와 3개의 theme component 소유
+    List<User> users = userScenarioSupport.builder()
+        .withUsers(2)
+        .build().users();
+    var dc = designComponentScenarioSupport.builder(users)
+        .withCountPerUser(3)
+        .build();
+    var tc = themeComponentScenarioSupport.builder(users)
+        .withCountPerUser(3)
+        .build();
+    // given: page=0, size=5로 설정
+    MultiValueMap<String, String> params = TestParams.withPaging(0, 5);
+    // when
+    User client = users.get(0);
+    List<ComponentCatalogResponse> response = mockMvcUtils.doAuthRequest(
+        MockMvcRequestDto.<Void, List<ComponentCatalogResponse>>builder()
+            .mockMvc(mockMvc)
+            .httpMethod(HttpMethod.GET)
+            .path("/api/users/me/custom-components")
+            .clientDto(TestClientDto.fromEntity(client))
+            .params(params)
+            .responseType(new TypeReference<>() {
+            })
+            .build()
+    );
+    // then
+    assertThat(response).hasSize(5);
+    for (ComponentCatalogResponse res : response) {
+      assertUserPostListResponseDto(res);
+    }
+  }
+}

--- a/src/test/java/com/komentum/post/controller/UserPostControllerTest.java
+++ b/src/test/java/com/komentum/post/controller/UserPostControllerTest.java
@@ -86,10 +86,15 @@ public class UserPostControllerTest {
     // response assertion
     assertThat(responseDto.getCreatedAt()).isNotNull();
     assertThat(responseDto.getUpdatedAt()).isNotNull();
-    assertThat(responseDto.getPreviewImageUrl()).isEqualTo(previewImageUrl);
+    assertThat(responseDto.getPreviewImageUrl())
+        .containsExactlyInAnyOrderElementsOf(List.of(previewImageUrl));
     assertThat(responseDto.getAuthorName()).isEqualTo(post.getUser().getName());
     assertThat(responseDto.getAuthorProfileImageUrl()).isEqualTo(post.getUser().getProfileImg());
     assertThat(responseDto.getPostType()).isEqualTo(post.getPostType());
+    assertThat(responseDto.getBookmarked()).isNotNull();
+    assertThat(responseDto.getPreferred()).isNotNull();
+    assertThat(responseDto.getComments()).isNotNull();
+    assertThat(responseDto.getPrefers()).isNotNull();
   }
 
   @Test

--- a/src/test/java/com/komentum/test/data/scenario/DesignComponentScenarioSupport.java
+++ b/src/test/java/com/komentum/test/data/scenario/DesignComponentScenarioSupport.java
@@ -1,0 +1,51 @@
+package com.komentum.test.data.scenario;
+
+import com.komentum.seed.seeder.DesignComponentSeeder;
+import com.komentum.theme.component.domain.DesignComponent;
+import com.komentum.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DesignComponentScenarioSupport {
+
+  private final DesignComponentSeeder designComponentSeeder;
+
+  public record DesignComponentScenarioResult(
+      List<DesignComponent> designComponents
+  ) {
+
+  }
+
+  public DesignComponentScenarioBuilder builder(List<User> users) {
+    return new DesignComponentScenarioBuilder(users);
+  }
+
+  public class DesignComponentScenarioBuilder {
+
+    private int countPerUser;
+    List<User> users;
+
+    public DesignComponentScenarioBuilder(List<User> users) {
+      this.users = users;
+    }
+
+    public DesignComponentScenarioBuilder withCountPerUser(int countPerUser) {
+      this.countPerUser = countPerUser;
+      return this;
+    }
+
+    public DesignComponentScenarioResult build() {
+      // generate design components
+      if (countPerUser <= 0) {
+        throw new IllegalArgumentException("countPerUser must bigger than 0");
+      }
+      List<DesignComponent> designComponents = designComponentSeeder.seedPeruser(countPerUser,
+          users);
+      // convert data to result
+      return new DesignComponentScenarioResult(designComponents);
+    }
+  }
+}

--- a/src/test/java/com/komentum/test/data/scenario/ThemeComponentScenarioSupport.java
+++ b/src/test/java/com/komentum/test/data/scenario/ThemeComponentScenarioSupport.java
@@ -1,0 +1,58 @@
+package com.komentum.test.data.scenario;
+
+import com.komentum.seed.seeder.ThemeComponentSeeder;
+import com.komentum.theme.component.service.ColorStyleSeeder;
+import com.komentum.theme.component.service.ComponentTypeSeeder;
+import com.komentum.theme.theme.domain.ThemeComponent;
+import com.komentum.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ThemeComponentScenarioSupport {
+
+  private final ThemeComponentSeeder themeComponentSeeder;
+  private final ComponentTypeSeeder componentTypeSeeder;
+  private final ColorStyleSeeder colorStyleSeeder;
+
+  public record ThemeComponentScenarioResult(
+      List<ThemeComponent> themeComponents
+  ) {
+
+  }
+
+  public ThemeComponentScenarioBuilder builder(List<User> users) {
+    return new ThemeComponentScenarioBuilder().builder(users);
+  }
+
+  public class ThemeComponentScenarioBuilder {
+
+    private List<User> users;
+    private int countPerUser;
+
+    public ThemeComponentScenarioBuilder builder(List<User> users) {
+      this.users = users;
+      return this;
+    }
+
+    public ThemeComponentScenarioBuilder withCountPerUser(int countPerUser) {
+      this.countPerUser = countPerUser;
+      return this;
+    }
+
+    public ThemeComponentScenarioResult build() {
+      // generate color style & component type
+      componentTypeSeeder.upsertComponentType();
+      colorStyleSeeder.upsertColorStyleSeed();
+      // generate theme components
+      if (countPerUser <= 0) {
+        throw new IllegalArgumentException("countPerUser must be bigger than 0");
+      }
+      List<ThemeComponent> themeComponents = themeComponentSeeder.seedPerUser(countPerUser, users);
+      // convert data to result
+      return new ThemeComponentScenarioResult(themeComponents);
+    }
+  }
+}

--- a/src/test/java/com/komentum/test/data/scenario/UserScenarioSupport.java
+++ b/src/test/java/com/komentum/test/data/scenario/UserScenarioSupport.java
@@ -1,0 +1,39 @@
+package com.komentum.test.data.scenario;
+
+import com.komentum.seed.seeder.UserSeeder;
+import com.komentum.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserScenarioSupport {
+
+  private final UserSeeder userSeeder;
+
+  public record UserScenarioResult(
+      List<User> users
+  ) {
+
+  }
+
+  public UserScenarioBuilder builder() {
+    return new UserScenarioBuilder();
+  }
+
+  public class UserScenarioBuilder {
+
+    private int userCount;
+
+    public UserScenarioBuilder withUsers(int userCount) {
+      this.userCount = userCount;
+      return this;
+    }
+
+    public UserScenarioResult build() {
+      List<User> users = userSeeder.seedData(userCount);
+      return new UserScenarioResult(users);
+    }
+  }
+}


### PR DESCRIPTION
## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용
- 사용자 북마크/업로드 게시글 조회 기능 개선 ( 필드 추가 )
  - 대표 이미지를 대표 이미지 목록으로 변경
  - 북마크 여부 필드 추가
  - 댓글 수 필드 추가
  - 좋아요 / 좋아요 여부 필드 추가
- 사용자가 커스텀한 테마 / 디자인 에셋 목록 날짜순 내림차순 정렬 및 조회 기능 추가
  - MySQL Native Query 기반으로 구현 ( UNION 기반 페이징 정확성 보장 목적 )
  - 별도 패키지 ( catalog )에서 구현 ( 특정 도메인에 포함된다고 보기 어려웠기 때문 )
- scenario builder 기반 테스트 데이터 생성기 구현
  - user, theme component, design component에 대한 scenario builder 구현

관련 이슈: #92  


## 테스트 결과

### 1. 통합 테스트 결과
<img width="1404" height="424" alt="image" src="https://github.com/user-attachments/assets/fd1287d2-d9e9-464d-9a20-cdeb6b69cc82" />
<img width="1024" height="491" alt="image" src="https://github.com/user-attachments/assets/f2e333ff-06c2-46c1-a8d9-5436a9cb4c64" />

### 2. 수동 테스트 결과 ( 1, 3, 5, 95, 96번 북마크 후 5번, 96번 북마크 해제 )
<img width="879" height="692" alt="image" src="https://github.com/user-attachments/assets/9d5e0e2d-bfe4-4b07-b423-d9be6b5e2dab" />

### 3. 수동 테스트 결과 ( 테마, 디자인 에셋 게시글 하나씩 생성 )
<img width="881" height="686" alt="image" src="https://github.com/user-attachments/assets/a33cd486-727a-4f12-af20-ed858de87632" />

### 4. 수동 테스트 결과 ( 내가 소유한 테마, 디자인 에셋 목록 조회, 총 20개 )
<img width="1395" height="629" alt="image" src="https://github.com/user-attachments/assets/0c0a4d03-9e51-4033-9cb4-9f072d200e0d" />


## PR 체크리스트
- [x] 커밋 메시지가 가이드라인을 따르는가
- [x] 테스트 코드를 모두 통과하였는가
- [x] 관련 이슈를 연결하였는가
