### PR TITLE
Feat/#94 토큰 재발급 기능 개선

### DIFF
--- a/src/main/java/com/komentum/auth/JwtUtils.java
+++ b/src/main/java/com/komentum/auth/JwtUtils.java
@@ -13,7 +13,6 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpRequest;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -21,6 +20,7 @@ import org.springframework.stereotype.Component;
 public class JwtUtils {
 
   String identifier = "publicUserId";
+  private final String TOKEN_TYPE_KEY = "tokenType";
   private final Key SECRET_KEY;
   private final AuthProperty authProperty;
 
@@ -33,9 +33,10 @@ public class JwtUtils {
   /**
    * generate token
    */
-  private String generateToken(String publicUserId, Long expTime) {
+  private String generateToken(String publicUserId, Long expTime, TokenType tokenType) {
     Claims claims = Jwts.claims().setSubject(publicUserId);
     claims.put(identifier, publicUserId);
+    claims.put(TOKEN_TYPE_KEY, tokenType.name());
     ZonedDateTime issuedDate = ZonedDateTime.now();
     ZonedDateTime expiresDate = issuedDate.plusSeconds(expTime);
     return Jwts.builder()
@@ -50,14 +51,14 @@ public class JwtUtils {
    * generate access token
    */
   public String generateAccessToken(String publicUserId) {
-    return generateToken(publicUserId, authProperty.getAccessTokenExpiresIn());
+    return generateToken(publicUserId, authProperty.getAccessTokenExpiresIn(), TokenType.ACCESS);
   }
 
   /**
    * generate refresh token
    */
   public String generateRefreshToken(String publicUserId) {
-    return generateToken(publicUserId, authProperty.getRefreshTokenExpiresIn());
+    return generateToken(publicUserId, authProperty.getRefreshTokenExpiresIn(), TokenType.REFRESH);
   }
 
   /**
@@ -91,16 +92,15 @@ public class JwtUtils {
     }
   }
 
-  /**
-   * extract token from request
-   */
-  public String resolveJwtToken(HttpRequest request) {
+  public String getTokenType(String token) {
     try {
-      String authorization = request.getHeaders().getFirst(AuthProperty.ACCESS_TOKEN_HEADER);
-      if (authorization == null || !authorization.startsWith(AuthProperty.ACCESS_TOKEN_PREFIX)) {
-        return null;
-      }
-      return authorization.substring(AuthProperty.ACCESS_TOKEN_PREFIX.length());
+      return Jwts
+          .parserBuilder()
+          .setSigningKey(SECRET_KEY)
+          .build()
+          .parseClaimsJws(token)
+          .getBody()
+          .get(TOKEN_TYPE_KEY, String.class);
     } catch (Exception e) {
       log.error(e.getMessage());
       return null;
@@ -113,20 +113,23 @@ public class JwtUtils {
    * @param request HttpServletRequest
    * @return jwt token without prefix or null if token not exists
    */
-  public String resolveJwtToken(HttpServletRequest request) {
+  public String resolveToken(HttpServletRequest request, String cookieName) {
     try {
-      String accessToken = extractAccessTokenFromHeader(request);
-      if (accessToken == null) {
-        accessToken = extractAccessTokenFromCookie(request);
+      String token = extractTokenFromHeader(request);
+      if (token == null) {
+        token = extractTokenFromCookie(request, cookieName);
       }
-      return accessToken;
+      return token;
     } catch (Exception e) {
       log.error(e.getMessage());
       return null;
     }
   }
 
-  private String extractAccessTokenFromHeader(HttpServletRequest request) {
+  /**
+   * 헤더에서 토큰를 추출하고, 없으면 null을 반환한다
+   * */
+  private String extractTokenFromHeader(HttpServletRequest request) {
     String authorization = request.getHeader(AuthProperty.ACCESS_TOKEN_HEADER);
     if (authorization == null || !authorization.startsWith(AuthProperty.ACCESS_TOKEN_PREFIX)) {
       return null;
@@ -134,15 +137,32 @@ public class JwtUtils {
     return authorization.substring(AuthProperty.ACCESS_TOKEN_PREFIX.length());
   }
 
-  private String extractAccessTokenFromCookie(HttpServletRequest request) {
+  /**
+   * 쿠키에서 토큰을 추출하고, 없으면 null을 반환한다
+   * */
+  private String extractTokenFromCookie(HttpServletRequest request, String cookieName) {
     Cookie[] cookies = request.getCookies();
     if (cookies == null) {
       return null;
     }
     return Arrays.stream(cookies)
-        .filter(c -> c.getName().equals(AuthProperty.ACCESS_TOKEN_COOKIE_NAME))
+        .filter(c -> c.getName().equals(cookieName))
         .map(Cookie::getValue)
         .findFirst()
         .orElse(null);
+  }
+
+  /**
+   * 토큰이 ACCESS_TOKEN인지 확인한다
+   * */
+  public boolean isAccessToken(String token) {
+    return token != null && TokenType.ACCESS.name().equals(getTokenType(token));
+  }
+
+  /**
+   * 토큰이 REFRESH_TOKEN인지 확인한다
+   * */
+  public boolean isRefreshToken(String token) {
+    return token != null && TokenType.REFRESH.name().equals(getTokenType(token));
   }
 }

--- a/src/main/java/com/komentum/auth/JwtUtils.java
+++ b/src/main/java/com/komentum/auth/JwtUtils.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 public class JwtUtils {
 
   String identifier = "publicUserId";
-  private final String TOKEN_TYPE_KEY = "tokenType";
+  private static final String TOKEN_TYPE_KEY = "tokenType";
   private final Key SECRET_KEY;
   private final AuthProperty authProperty;
 

--- a/src/main/java/com/komentum/auth/TokenType.java
+++ b/src/main/java/com/komentum/auth/TokenType.java
@@ -1,0 +1,5 @@
+package com.komentum.auth;
+
+public enum TokenType {
+  ACCESS, REFRESH
+}

--- a/src/main/java/com/komentum/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/komentum/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
-package com.komentum.theme.exception;
+package com.komentum.global.exception;
 
+import com.komentum.theme.exception.ResourceNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -46,5 +47,13 @@ public class GlobalExceptionHandler {
     Map<String, String> errors = new HashMap<>();
     errors.put("message", ex.getMessage());
     return new ResponseEntity<>(errors, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(UnauthorizedException.class)
+  public ResponseEntity<Map<String, String>> handleUnauthorizedException(
+      AccessDeniedException ex) {
+    Map<String, String> errors = new HashMap<>();
+    errors.put("message", ex.getMessage());
+    return new ResponseEntity<>(errors, HttpStatus.UNAUTHORIZED);
   }
 }

--- a/src/main/java/com/komentum/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/komentum/global/exception/GlobalExceptionHandler.java
@@ -51,7 +51,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(UnauthorizedException.class)
   public ResponseEntity<Map<String, String>> handleUnauthorizedException(
-      AccessDeniedException ex) {
+      UnauthorizedException ex) {
     Map<String, String> errors = new HashMap<>();
     errors.put("message", ex.getMessage());
     return new ResponseEntity<>(errors, HttpStatus.UNAUTHORIZED);

--- a/src/main/java/com/komentum/global/exception/UnauthorizedException.java
+++ b/src/main/java/com/komentum/global/exception/UnauthorizedException.java
@@ -1,0 +1,12 @@
+package com.komentum.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UnauthorizedException extends RuntimeException {
+
+  public UnauthorizedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/komentum/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/komentum/global/security/JwtAuthFilter.java
@@ -35,7 +35,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     handleAccessToken(request);
     // 토큰 재발급 요청인 경우, 유효한 refresh token가 있어야하고, 없으면 401 응답을 반환한다
     if (isReissueRequest(request) && !handleRefreshToken(request)) {
-      System.out.println("invalid refresh token");
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
       return;
     }

--- a/src/main/java/com/komentum/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/komentum/global/security/JwtAuthFilter.java
@@ -1,6 +1,7 @@
 package com.komentum.global.security;
 
 import com.komentum.auth.JwtUtils;
+import com.komentum.global.properties.AuthProperty;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,6 +12,8 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -21,12 +24,32 @@ public class JwtAuthFilter extends OncePerRequestFilter {
   private final JwtUtils jwtUtils;
   private final CustomUserDetailsService userDetailsService;
 
+  private final RequestMatcher reissueMatcher =
+      new AntPathRequestMatcher("/api/auth/reissue", "POST");
+
   @Override
   protected void doFilterInternal(@NonNull HttpServletRequest request,
       @NonNull HttpServletResponse response,
       @NonNull FilterChain filterChain) throws ServletException, IOException {
-    Optional.ofNullable(jwtUtils.resolveJwtToken(request)) // 요청에서 토큰 추출
+    // access token 기반 인증 및 인가
+    handleAccessToken(request);
+    // 토큰 재발급 요청인 경우, 유효한 refresh token가 있어야하고, 없으면 401 응답을 반환한다
+    if (isReissueRequest(request) && !handleRefreshToken(request)) {
+      System.out.println("invalid refresh token");
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return;
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * access token을 추출하고, 유효한다면 Authentication 객체를 추가(인가)한다.
+   * */
+  private void handleAccessToken(HttpServletRequest request) {
+    Optional.ofNullable(
+            jwtUtils.resolveToken(request, AuthProperty.ACCESS_TOKEN_COOKIE_NAME)) // 요청에서 토큰 추출
         .filter(jwtUtils::validateToken) // 추출된 토큰의 유효성 확인
+        .filter(jwtUtils::isAccessToken) // 토큰이 access token인지 확인
         .map(jwtUtils::getUserId) // 토큰에서 사용자 아이디 추출
         .map(userDetailsService::loadUserByUsername) // 사용자 아이디를 통해 UserDetails 혹은 null을 받음
         .ifPresent( // UserDetails가 null이 아니라면, 인증 정보를 SecurityContext에 저장
@@ -35,6 +58,22 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                   userDetails, null, userDetails.getAuthorities());
               SecurityContextHolder.getContext().setAuthentication(authToken);
             });
-    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * 현재 요청이 토큰 재발급 요청인지 확인한다
+   * */
+  private boolean isReissueRequest(HttpServletRequest request) {
+    return reissueMatcher.matches(request);
+  }
+
+  /**
+   * 현재 요청에 유효한 REFRESH_TOKEN이 존재하는지 확인한다.
+   * */
+  private boolean handleRefreshToken(HttpServletRequest request) {
+    String refreshToken = jwtUtils.resolveToken(request, AuthProperty.REFRESH_TOKEN_COOKIE_NAME);
+    return refreshToken != null &&
+        jwtUtils.validateToken(refreshToken) &&
+        jwtUtils.isRefreshToken(refreshToken);
   }
 }

--- a/src/main/java/com/komentum/global/security/OAuth2LogInSuccessHandler.java
+++ b/src/main/java/com/komentum/global/security/OAuth2LogInSuccessHandler.java
@@ -4,6 +4,7 @@ import com.komentum.auth.JwtUtils;
 import com.komentum.global.dto.CustomOAuth2User;
 import com.komentum.global.properties.AuthProperty;
 import com.komentum.global.security.cookie.TokenCookieManager;
+import com.komentum.user.service.TokenService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,6 +21,7 @@ public class OAuth2LogInSuccessHandler extends SimpleUrlAuthenticationSuccessHan
   private final JwtUtils jwtUtils;
   private final AuthProperty authProperty;
   private final TokenCookieManager tokenCookieManager;
+  private final TokenService tokenService;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -29,7 +31,8 @@ public class OAuth2LogInSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     String accessToken = jwtUtils.generateAccessToken(oAuth2User.getUserIdentifier());
     String refreshToken = jwtUtils.generateRefreshToken(oAuth2User.getUserIdentifier());
     tokenCookieManager.addTokenOnCookie(response, accessToken, refreshToken);
-
+    tokenService.saveAccessAndRefreshToken(oAuth2User.getUserIdentifier(), accessToken,
+        refreshToken);
     String redirectUrl = authProperty.getOauth2RedirectUrl();
     response.sendRedirect(redirectUrl);
   }

--- a/src/main/java/com/komentum/user/controller/DevAuthController.java
+++ b/src/main/java/com/komentum/user/controller/DevAuthController.java
@@ -32,7 +32,7 @@ public class DevAuthController {
     User user = userSeeder.createOrRetrieveRootUser();
     String accessToken = jwtUtils.generateAccessToken(user.getPublicUserId());
     String refreshToken = jwtUtils.generateRefreshToken(user.getPublicUserId());
-    tokenService.saveAccessAndRefreshToken(user.getUserEmail(), accessToken, refreshToken);
+    tokenService.saveAccessAndRefreshToken(user.getPublicUserId(), accessToken, refreshToken);
     tokenCookieManager.addTokenOnCookie(response, accessToken, refreshToken);
     return ResponseEntity.ok(new UserAuthResponse(accessToken, refreshToken));
   }

--- a/src/main/java/com/komentum/user/controller/UserAuthController.java
+++ b/src/main/java/com/komentum/user/controller/UserAuthController.java
@@ -52,7 +52,7 @@ public class UserAuthController {
   @PostMapping("/local/sign-out")
   @Operation(summary = "인증된 사용자가 로그아웃을 진행한다")
   public ResponseEntity<String> signOut(HttpServletRequest request, HttpServletResponse response) {
-    String accessToken = jwtUtils.resolveToken(request, AuthProperty.ACCESS_TOKEN_HEADER);
+    String accessToken = jwtUtils.resolveToken(request, AuthProperty.ACCESS_TOKEN_COOKIE_NAME);
     if (!jwtUtils.isAccessToken(accessToken)) {
       throw new IllegalArgumentException("invalid access token");
     }

--- a/src/main/java/com/komentum/user/controller/UserAuthController.java
+++ b/src/main/java/com/komentum/user/controller/UserAuthController.java
@@ -53,7 +53,10 @@ public class UserAuthController {
   @PostMapping("/local/sign-out")
   @Operation(summary = "인증된 사용자가 로그아웃을 진행한다")
   public ResponseEntity<String> signOut(HttpServletRequest request, HttpServletResponse response) {
-    String accessToken = jwtUtils.resolveJwtToken(request);
+    String accessToken = jwtUtils.resolveToken(request, AuthProperty.ACCESS_TOKEN_HEADER);
+    if (!jwtUtils.isAccessToken(accessToken)) {
+      throw new IllegalArgumentException("invalid access token");
+    }
     userAuthService.handleLogout(accessToken);
     tokenCookieManager.removeTokenOnCookie(response);
     return ResponseEntity.ok("logout success");

--- a/src/main/java/com/komentum/user/controller/UserAuthController.java
+++ b/src/main/java/com/komentum/user/controller/UserAuthController.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -66,11 +65,15 @@ public class UserAuthController {
   /**
    * 토큰 재발급
    */
-  @PostMapping("/token")
-  @Operation(summary = "인증된 사용자의 refresh token으로 토큰을 재발급한다")
-  public ResponseEntity<UserAuthResponse> generateToken(
-      @RequestHeader(AuthProperty.ACCESS_TOKEN_HEADER) String refreshToken) {
-    refreshToken = refreshToken.replace(AuthProperty.ACCESS_TOKEN_PREFIX, "");
-    return ResponseEntity.ok(userAuthService.doRefreshTokenRotation(refreshToken));
+  @PostMapping("/reissue")
+  @Operation(summary = "인증된 사용자의 refresh token으로 access token을 재발급한다")
+  public ResponseEntity<UserAuthResponse> reissueToken(HttpServletRequest request,
+      HttpServletResponse response) {
+    String refreshToken = jwtUtils.resolveToken(request, AuthProperty.REFRESH_TOKEN_COOKIE_NAME);
+    UserAuthResponse tokenResponse = userAuthService.doRefreshTokenRotation(refreshToken);
+    tokenCookieManager.removeTokenOnCookie(response);
+    tokenCookieManager.addTokenOnCookie(response, tokenResponse.getAccessToken(),
+        tokenResponse.getRefreshToken());
+    return ResponseEntity.ok(tokenResponse);
   }
 }

--- a/src/main/java/com/komentum/user/dto/SignUpRequestDto.java
+++ b/src/main/java/com/komentum/user/dto/SignUpRequestDto.java
@@ -4,11 +4,13 @@ import com.komentum.global.security.UserRole;
 import com.komentum.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Data
 @Schema(description = "로컬 회원가입 요청 DTO")
+@AllArgsConstructor
 public class SignUpRequestDto {
 
   @Schema(description = "가입할 사용자 이메일", example = "newuser@test.com")

--- a/src/main/java/com/komentum/user/dto/SignUpRequestDto.java
+++ b/src/main/java/com/komentum/user/dto/SignUpRequestDto.java
@@ -5,10 +5,12 @@ import com.komentum.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-@Data
+@Getter
+@Setter
 @Schema(description = "로컬 회원가입 요청 DTO")
 @AllArgsConstructor
 public class SignUpRequestDto {

--- a/src/main/java/com/komentum/user/redis/RedisSingleDataService.java
+++ b/src/main/java/com/komentum/user/redis/RedisSingleDataService.java
@@ -1,10 +1,11 @@
 package com.komentum.user.redis;
 
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
-
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -37,6 +38,16 @@ public class RedisSingleDataService {
     } catch (Exception e) {
       log.error(e.getMessage());
       return false;
+    }
+  }
+
+  public Long executeLua(String script, List<String> keys, String... args) {
+    try {
+      DefaultRedisScript<Long> redisScript = new DefaultRedisScript<>(script, Long.class);
+      return redisTemplate.execute(redisScript, keys, (Object[]) args.clone());
+    } catch (Exception e) {
+      log.error("Redis Lua execution error: {}", e.getMessage(), e);
+      return null;
     }
   }
 }

--- a/src/main/java/com/komentum/user/service/TokenService.java
+++ b/src/main/java/com/komentum/user/service/TokenService.java
@@ -2,6 +2,7 @@ package com.komentum.user.service;
 
 import com.komentum.global.properties.AuthProperty;
 import com.komentum.user.redis.RedisSingleDataService;
+import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,43 +18,74 @@ public class TokenService {
     this.authProperty = authProperty;
   }
 
-  public String getAccessTokenKey(String email) {
-    return "access_token_" + email;
+  public String getAccessTokenKey(String userIdentifier) {
+    return "access_token_" + userIdentifier;
   }
 
-  public String getRefreshTokenKey(String email) {
-    return "refresh_token_" + email;
+  public String getRefreshTokenKey(String userIdentifier) {
+    return "refresh_token_" + userIdentifier;
   }
 
-  public boolean saveAccessToken(String email, String accessToken) {
-    return redisSingleDataService.set(getAccessTokenKey(email), accessToken,
+  public boolean saveAccessToken(String userIdentifier, String accessToken) {
+    return redisSingleDataService.set(getAccessTokenKey(userIdentifier), accessToken,
         authProperty.getAccessTokenExpiresIn().intValue());
   }
 
-  public boolean saveRefreshToken(String email, String refreshToken) {
-    return redisSingleDataService.set(getRefreshTokenKey(email), refreshToken,
+  public boolean saveRefreshToken(String userIdentifier, String refreshToken) {
+    return redisSingleDataService.set(getRefreshTokenKey(userIdentifier), refreshToken,
         authProperty.getRefreshTokenExpiresIn().intValue());
   }
 
-  public boolean saveAccessAndRefreshToken(String email, String accessToken, String refreshToken) {
-    boolean success1 = saveAccessToken(email, accessToken);
-    boolean success2 = saveRefreshToken(email, refreshToken);
+  public boolean saveAccessAndRefreshToken(String userIdentifier, String accessToken,
+      String refreshToken) {
+    boolean success1 = saveAccessToken(userIdentifier, accessToken);
+    boolean success2 = saveRefreshToken(userIdentifier, refreshToken);
     return success1 && success2;
+  }
+
+  /**
+   * 저장된 토큰과 prevRefreshToken이 일치하면 토큰을 교체하고, 그렇지 않다면 교체하지 않는다
+   * @param userIdentifier 사용자 식별자
+   * @param prevRefreshToken 현재 사용하고 있는 refresh token
+   * @param newRefreshToken 새로 사용할 refresh token
+   * */
+  public boolean rotateRefreshToken(String userIdentifier, String prevRefreshToken,
+      String newRefreshToken) {
+    String key = getRefreshTokenKey(userIdentifier);
+    // 동시성 문제 해결 : Lua Script 실행 ( 연속 2회 요청 등의 문제 대비 )
+    String script = """
+        local current = redis.call("GET", KEYS[1])
+        if current == ARGV[1] then
+            redis.call("SET", KEYS[1], ARGV[2], "EX", ARGV[3])
+            return 1
+        else
+            return 0
+        end
+        """;
+    // Lua Script 실행
+    Long result = redisSingleDataService.executeLua(
+        script,
+        List.of(key),
+        prevRefreshToken,
+        newRefreshToken,
+        String.valueOf(authProperty.getRefreshTokenExpiresIn())
+    );
+    return result != null && result == 1L;
   }
 
   public String getAccessToken(String email) {
     return redisSingleDataService.get(getAccessTokenKey(email));
   }
 
-  public String getRefreshToken(String email) {
-    return redisSingleDataService.get(getRefreshTokenKey(email));
+  public String getRefreshToken(String userIdentifier) {
+    return redisSingleDataService.get(getRefreshTokenKey(userIdentifier));
   }
 
-  public boolean deleteAccessToken(String email) {
-    return redisSingleDataService.delete(getAccessTokenKey(email));
+  public boolean deleteAccessToken(String userIdentifier) {
+    return redisSingleDataService.delete(getAccessTokenKey(userIdentifier));
   }
 
-  public boolean deleteRefreshToken(String email) {
-    return redisSingleDataService.delete(getRefreshTokenKey(email));
+  public boolean deleteRefreshToken(String userIdentifier) {
+    return redisSingleDataService.delete(getRefreshTokenKey(userIdentifier));
   }
 }

--- a/src/main/java/com/komentum/user/service/UserAuthService.java
+++ b/src/main/java/com/komentum/user/service/UserAuthService.java
@@ -2,6 +2,7 @@ package com.komentum.user.service;
 
 import com.komentum.auth.JwtUtils;
 import com.komentum.global.dto.CustomUserDetails;
+import com.komentum.global.exception.UnauthorizedException;
 import com.komentum.global.properties.AuthProperty;
 import com.komentum.global.security.CustomUserDetailsService;
 import com.komentum.user.client.KakaoAuthHttpClient;
@@ -16,8 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.bind.annotation.RequestHeader;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
 
 @Service
 public class UserAuthService {
@@ -54,24 +53,6 @@ public class UserAuthService {
       throw new RuntimeException("failed to save access and refresh token");
     }
     return new UserAuthResponse(accessToken, refreshToken);
-  }
-
-  /**
-   * 카카오 로그인 및 회원가입
-   */
-  @Transactional
-  public Mono<UserAuthResponse> processKakaoAuth(String authCode) {
-    return kakaoAuthHttpClient.processLogin(authCode)
-        .flatMap(userInfo ->
-            Mono.fromCallable(() -> transactionTemplate.execute(status -> {
-                  User user = userRepository.findById(userInfo.getEmail()).orElse(null);
-                  if (user == null) {
-                    user = userRepository.save(userInfo.toEntity());
-                  }
-                  return initializeToken(user.getPublicUserId());
-                }
-            )).subscribeOn(Schedulers.boundedElastic())
-        );
   }
 
 
@@ -132,31 +113,24 @@ public class UserAuthService {
   /**
    * refresh token 으로 토큰 재발급
    */
-  public UserAuthResponse doRefreshTokenRotation(String refreshToken) {
-    validateRefreshToken(refreshToken);
-    String userEmail = jwtUtils.getUserId(refreshToken);
-    String newAccessToken = jwtUtils.generateAccessToken(userEmail);
-    String newRefreshToken = jwtUtils.generateRefreshToken(userEmail);
-    if (!tokenService.saveAccessAndRefreshToken(userEmail, newAccessToken, newRefreshToken)) {
-      throw new RuntimeException("failed to save access and refresh token");
+  public UserAuthResponse doRefreshTokenRotation(String oldRefreshToken) {
+    // refresh token 유효성 여부 확인
+    if (!jwtUtils.validateToken(oldRefreshToken) || !jwtUtils.isRefreshToken(oldRefreshToken)) {
+      throw new UnauthorizedException("[token reissue failed] refresh token is invalid or expired");
+    }
+    // refresh token rotation ( 기존 refresh 토큰과 비교 및 교체 )
+    String publicUserId = jwtUtils.getUserId(oldRefreshToken);
+    String newAccessToken = jwtUtils.generateAccessToken(publicUserId);
+    String newRefreshToken = jwtUtils.generateRefreshToken(publicUserId);
+    boolean rotated = tokenService.rotateRefreshToken(
+        publicUserId,
+        oldRefreshToken,
+        newRefreshToken
+    );
+    if (!rotated) {
+      tokenService.deleteRefreshToken(publicUserId);
+      throw new UnauthorizedException("[token reissue failed] refresh token is already reused");
     }
     return new UserAuthResponse(newAccessToken, newRefreshToken);
-  }
-
-  /**
-   * refresh token 유효성 검사
-   */
-  void validateRefreshToken(String refreshToken) {
-    if (refreshToken == null || !jwtUtils.validateToken(refreshToken)) {
-      throw new RuntimeException("Invalid refresh token");
-    }
-    String email = jwtUtils.getUserId(refreshToken);
-    String stored = tokenService.getRefreshToken(email);
-    if (stored == null || !stored.equals(refreshToken)) {
-      if (stored != null) {
-        tokenService.deleteRefreshToken(email);
-      }
-      throw new RuntimeException("Invalid refresh token : prev version");
-    }
   }
 }

--- a/src/test/java/com/komentum/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/com/komentum/user/controller/UserAuthControllerTest.java
@@ -1,10 +1,16 @@
 package com.komentum.user.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HttpHeaders;
 import com.komentum.auth.JwtUtils;
+import com.komentum.global.properties.AuthProperty;
+import com.komentum.test.MockMvcUtils;
 import com.komentum.test.config.EnableTestProfile;
 import com.komentum.test.data.UserDataGenerator;
 import com.komentum.user.domain.User;
@@ -12,6 +18,7 @@ import com.komentum.user.dto.LocalLoginRequestDto;
 import com.komentum.user.dto.PasswordChangeRequsetDto;
 import com.komentum.user.dto.UserAuthResponse;
 import com.komentum.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,8 +56,12 @@ class UserAuthControllerTest {
   private JwtUtils jwtUtils;
   @Autowired
   private BCryptPasswordEncoder passwordEncoder;
+  @Autowired
+  private MockMvcUtils mockMvcUtils;
 
   User user;
+
+  User testClient;
 
   @BeforeEach
   void setUp() {
@@ -141,4 +152,69 @@ class UserAuthControllerTest {
 
     assertThat(updatedUSer.matchPassword(newPassword, passwordEncoder)).isTrue();
   }
+
+  @Test
+  @DisplayName("when send request, rotate refresh token and return new tokens")
+  public void doRefreshTokenRotation_success() throws Exception {
+    // given: 사용자 1명 로그인 처리
+    LocalLoginRequestDto localLoginRequestDto = new LocalLoginRequestDto(email, password);
+    String response = mockMvc.perform(
+        MockMvcRequestBuilders.post("/api/auth/local/sign-in")
+            .content(objectMapper.writeValueAsString(localLoginRequestDto))
+            .contentType(MediaType.APPLICATION_JSON)
+    ).andReturn().getResponse().getContentAsString();
+    UserAuthResponse tokenResponse = objectMapper.readValue(response, UserAuthResponse.class);
+    // when: 토큰 재발급 시도
+    String newResponse = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/auth/reissue")
+                .cookie(
+                    new Cookie(AuthProperty.REFRESH_TOKEN_COOKIE_NAME, tokenResponse.getRefreshToken())
+                )
+        )
+        .andExpect(header().stringValues(
+            HttpHeaders.SET_COOKIE,
+            hasItem(containsString(AuthProperty.ACCESS_TOKEN_COOKIE_NAME))
+        ))
+        .andExpect(header().stringValues(
+            HttpHeaders.SET_COOKIE,
+            hasItem(containsString(AuthProperty.REFRESH_TOKEN_COOKIE_NAME))
+        ))
+        .andReturn().getResponse().getContentAsString();
+    UserAuthResponse newTokenResponse = objectMapper.readValue(newResponse, UserAuthResponse.class);
+    // then: 토큰 유효성 확인
+    assertThat(jwtUtils.isAccessToken(newTokenResponse.getAccessToken())).isTrue();
+    assertThat(jwtUtils.validateToken(newTokenResponse.getAccessToken())).isTrue();
+    assertThat(jwtUtils.isRefreshToken(newTokenResponse.getRefreshToken())).isTrue();
+    assertThat(jwtUtils.validateToken(newTokenResponse.getRefreshToken())).isTrue();
+    // then: 새로운 토큰이 발급되었는지 확인
+    assertThat(newTokenResponse.getAccessToken()).isNotEqualTo(tokenResponse.getAccessToken());
+    assertThat(newTokenResponse.getRefreshToken()).isNotEqualTo(tokenResponse.getRefreshToken());
+  }
+
+  @Test
+  @DisplayName("when send request with used refresh token, throw 401 exception")
+  public void doRefreshTokenRotation_withUsedRefreshToken() throws Exception {
+    // given: 사용자 1명 로그인 처리
+    LocalLoginRequestDto localLoginRequestDto = new LocalLoginRequestDto(email, password);
+    String response = mockMvc.perform(
+        MockMvcRequestBuilders.post("/api/auth/local/sign-in")
+            .content(objectMapper.writeValueAsString(localLoginRequestDto))
+            .contentType(MediaType.APPLICATION_JSON)
+    ).andReturn().getResponse().getContentAsString();
+    UserAuthResponse tokenResponse = objectMapper.readValue(response, UserAuthResponse.class);
+    // when: 토큰 재발급 시도
+    mockMvc.perform(
+        MockMvcRequestBuilders.post("/api/auth/reissue")
+            .cookie(
+                new Cookie(AuthProperty.REFRESH_TOKEN_COOKIE_NAME, tokenResponse.getRefreshToken()))
+    );
+    // when: 이전에 사용한 refresh token 재사용
+    mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/auth/reissue")
+                .cookie(
+                    new Cookie(AuthProperty.REFRESH_TOKEN_COOKIE_NAME, tokenResponse.getRefreshToken()))
+        )
+        .andExpect(status().isUnauthorized());
+  }
+
 }

--- a/src/test/java/com/komentum/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/com/komentum/user/controller/UserAuthControllerTest.java
@@ -165,6 +165,7 @@ class UserAuthControllerTest {
     ).andReturn().getResponse().getContentAsString();
     UserAuthResponse tokenResponse = objectMapper.readValue(response, UserAuthResponse.class);
     // when: 토큰 재발급 시도
+    Thread.sleep(500);
     String newResponse = mockMvc.perform(
             MockMvcRequestBuilders.post("/api/auth/reissue")
                 .cookie(
@@ -203,6 +204,7 @@ class UserAuthControllerTest {
     ).andReturn().getResponse().getContentAsString();
     UserAuthResponse tokenResponse = objectMapper.readValue(response, UserAuthResponse.class);
     // when: 토큰 재발급 시도
+    Thread.sleep(500);
     mockMvc.perform(
         MockMvcRequestBuilders.post("/api/auth/reissue")
             .cookie(

--- a/src/test/java/com/komentum/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/com/komentum/user/controller/UserAuthControllerTest.java
@@ -165,7 +165,7 @@ class UserAuthControllerTest {
     ).andReturn().getResponse().getContentAsString();
     UserAuthResponse tokenResponse = objectMapper.readValue(response, UserAuthResponse.class);
     // when: 토큰 재발급 시도
-    Thread.sleep(500);
+    Thread.sleep(1000);
     String newResponse = mockMvc.perform(
             MockMvcRequestBuilders.post("/api/auth/reissue")
                 .cookie(
@@ -204,7 +204,7 @@ class UserAuthControllerTest {
     ).andReturn().getResponse().getContentAsString();
     UserAuthResponse tokenResponse = objectMapper.readValue(response, UserAuthResponse.class);
     // when: 토큰 재발급 시도
-    Thread.sleep(500);
+    Thread.sleep(1000);
     mockMvc.perform(
         MockMvcRequestBuilders.post("/api/auth/reissue")
             .cookie(


### PR DESCRIPTION
## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용
- refresh token 기반 토큰 재발급 API에 한하여, refresh token이 유효하지 않으면 401 응답을 하도록 설정
- 토큰 종류를 claim에 추가 ( ACCESS | REFRESH ) 
- refresh token rotation 동시성 문제 해결 ( redis lua script )
- 소셜 로그인 시 토큰을 저장소에 저장하지 않는 문제 수정 )
- refresh token rotation 시 토큰 재발급 후, 해당 토큰을 쿠키에도 저장하도록 변경

관련 이슈: #94 


## 테스트 결과

### 1. 통합테스트
<img width="1324" height="548" alt="image" src="https://github.com/user-attachments/assets/7384a8b4-7180-46e6-b535-f0d1de390301" />


### 2. 수동 테스트 ( 로컬 로그인 후 토큰 재발급 ) 
<img width="1085" height="708" alt="image" src="https://github.com/user-attachments/assets/f723fa91-81ea-4371-902e-8553e406143f" />

### 3. 수동 테스트 ( 소셜 로그인 후 토큰 재발급 )
<img width="1178" height="624" alt="image" src="https://github.com/user-attachments/assets/42bdbfe1-96b6-46a0-93d6-425572e46a01" />
<img width="1035" height="673" alt="image" src="https://github.com/user-attachments/assets/4b9fb486-889f-4065-90d6-b6506729a03d" />


### 4. 수동 테스트 ( 로그인하지 않은 상태에서 토큰 재발급 )
<img width="932" height="694" alt="image" src="https://github.com/user-attachments/assets/02d265de-60f9-4d79-a122-95fe3791bbf4" />

### 5. 수동 테스트 ( 이전에 사용한 refresh token으로 재요청 )
<img width="1189" height="754" alt="image" src="https://github.com/user-attachments/assets/8cf402ad-d82a-4800-905a-6af7b32c13f7" />

## PR 체크리스트
- [x] 커밋 메시지가 가이드라인을 따르는가
- [x] 테스트 코드를 모두 통과하였는가
- [x] 관련 이슈를 연결하였는가
