### PR TITLE
Feat/#100 인기 / 북마크한 테마 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.3'
     id 'io.spring.dependency-management' version '1.1.7'
+//    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.komentum'
@@ -14,6 +15,12 @@ springBoot {
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
     }
 }
 
@@ -77,6 +84,7 @@ dependencies {
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     // mapstruct
@@ -105,7 +113,6 @@ tasks.register("copyTestConfig", Copy) {
 processResources.dependsOn(copyConfig)
 processTestResources.dependsOn(copyTestConfig)
 // ### config settings end
-
 
 // ### query-dsl settings start
 def generated = 'src/main/generated'

--- a/src/main/java/com/komentum/post/controller/CommentController.java
+++ b/src/main/java/com/komentum/post/controller/CommentController.java
@@ -9,7 +9,7 @@ import com.komentum.post.facade.CommentManagementFacade;
 import com.komentum.post.service.CommentLikeService;
 import com.komentum.post.service.CommentService;
 import com.komentum.user.domain.User;
-import com.komentum.user.service.UserRetrieveService;
+import com.komentum.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import java.util.Set;
@@ -35,7 +35,7 @@ public class CommentController {
 
   private final CommentService commentService;
   private final CommentLikeService commentLikeService;
-  private final UserRetrieveService userRetrieveService;
+  private final UserService userRetrieveService;
   private final CommentManagementFacade commentManagementFacade;
 
   @GetMapping("/{post_id}/comments")

--- a/src/main/java/com/komentum/post/repository/PostRepositorySupport.java
+++ b/src/main/java/com/komentum/post/repository/PostRepositorySupport.java
@@ -14,6 +14,8 @@ import com.komentum.user.domain.QUser;
 import com.komentum.user.domain.User;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -190,5 +192,16 @@ public class PostRepositorySupport {
     return JPAExpressions.select(comment.count())
         .from(comment)
         .where(comment.post.eq(post));
+  }
+
+  public NumberExpression<Long> makePreferCountExpression(QPost post, QPrefer prefer) {
+    return Expressions.numberTemplate(
+        Long.class,
+        "({0})",
+        JPAExpressions
+            .select(prefer.preferId.countDistinct())
+            .from(prefer)
+            .where(prefer.post.eq(post))
+    );
   }
 }

--- a/src/main/java/com/komentum/seed/DevDataGenerator.java
+++ b/src/main/java/com/komentum/seed/DevDataGenerator.java
@@ -44,10 +44,11 @@ public class DevDataGenerator {
     colorStyleSeeder.upsertColorStyleSeed();
     List<DesignComponent> designComponents = designComponentSeeder.seedPeruser(10,
         users); // 110
-    List<ThemeComponent> themeComponents = themeComponentSeeder.seedPerUser(10, users); // 110
+    List<ThemeComponent> themeComponents = themeComponentSeeder.seedPerUser(10, users,
+        designComponents); // 110
     themeBoardSeeder.seedData(themeComponents.subList(0, 90)); //
     designBoardSeeder.seedData(designComponents.subList(0, 90)); // 100
     commentSeeder.seedPerPost(5, users); // 550
-    preferSeeder.seedPerPost(5, users); // 550
+    preferSeeder.seedPerPost(5, users, 0.5); // 550
   }
 }

--- a/src/main/java/com/komentum/seed/seeder/BookmarkSeeder.java
+++ b/src/main/java/com/komentum/seed/seeder/BookmarkSeeder.java
@@ -28,6 +28,11 @@ public class BookmarkSeeder {
   private final CategoryPostRepository categoryPostRepository;
   private final Faker faker;
 
+  public static record BookmarkSeedResult(List<Category> bookmarks,
+                                          List<CategoryPost> bookmarkMappings) {
+
+  }
+
   public Category createBookmark(User user) {
     return Category.builder()
         .name(faker.animal().name())
@@ -44,7 +49,7 @@ public class BookmarkSeeder {
   }
 
   @Transactional
-  public List<Category> bookmarkByRatio(List<User> users, List<Post> posts, double ratio) {
+  public BookmarkSeedResult bookmarkByRatio(List<User> users, List<Post> posts, double ratio) {
     if (ratio < 0 || ratio > 1) {
       throw new IllegalArgumentException("BookmarkSeeder : ratio must be between 0 and 1");
     }
@@ -76,7 +81,7 @@ public class BookmarkSeeder {
         postMappings.add(createBookmarkPost(bookmark, post));
       }
     }
-    categoryPostRepository.saveAll(postMappings);
-    return allBookmarks;
+    List<CategoryPost> bookmarkMappings = categoryPostRepository.saveAll(postMappings);
+    return new BookmarkSeedResult(allBookmarks, bookmarkMappings);
   }
 }

--- a/src/main/java/com/komentum/seed/seeder/CategorySeeder.java
+++ b/src/main/java/com/komentum/seed/seeder/CategorySeeder.java
@@ -47,7 +47,8 @@ public class CategorySeeder {
   }
 
   @Transactional
-  public void seedPostMappingsPerCategory(int categoryPostPerCategory, List<Category> categories,
+  public List<CategoryPost> seedPostMappingsPerCategory(int categoryPostPerCategory,
+      List<Category> categories,
       List<Post> posts) {
     List<CategoryPost> categoryPosts = new ArrayList<>();
     for (int i = 0; i < categories.size(); i++) {
@@ -56,6 +57,6 @@ public class CategorySeeder {
         categoryPosts.add(createOneCategoryPost(category, posts.get(j % posts.size())));
       }
     }
-    categoryPostRepository.saveAll(categoryPosts);
+    return categoryPostRepository.saveAll(categoryPosts);
   }
 }

--- a/src/main/java/com/komentum/seed/seeder/PreferSeeder.java
+++ b/src/main/java/com/komentum/seed/seeder/PreferSeeder.java
@@ -32,12 +32,15 @@ public class PreferSeeder {
   }
 
   @Transactional
-  public List<Prefer> seedPerPost(int preferPerPost, List<User> likerList) {
+  public List<Prefer> seedPerPost(int preferPerPost, List<User> likerList, double postRatio) {
     if (likerList.size() < preferPerPost) {
       throw new IllegalArgumentException(
           "liker list size must be bigger than prefer count per post");
     }
     List<Post> posts = postRepository.findAll();
+    List<Post> shuffledPosts = new ArrayList<>(posts);
+    Collections.shuffle(shuffledPosts);
+    List<Post> selectedPosts = shuffledPosts.subList(0, (int) (posts.size() * postRatio));
     List<Prefer> existingPrefers = preferRepository.fetchJoinByPostIn(posts);
     Map<User, Set<Post>> userPostPreferMap = existingPrefers.stream()
         .collect(Collectors.groupingBy(
@@ -51,7 +54,7 @@ public class PreferSeeder {
             Prefer::getPost,
             Collectors.toSet()));
     List<Prefer> prefers = new ArrayList<>();
-    for (Post post : posts) {
+    for (Post post : selectedPosts) {
       Set<Prefer> existing = existingPostPreferMap.getOrDefault(post, Collections.emptySet());
       int created = existing.size();
       for (User liker : likerList) {

--- a/src/main/java/com/komentum/seed/seeder/ThemeBoardSeeder.java
+++ b/src/main/java/com/komentum/seed/seeder/ThemeBoardSeeder.java
@@ -29,6 +29,13 @@ public class ThemeBoardSeeder {
   private final FileManager fileManager;
   private final Faker faker;
 
+  public static record ThemeBoardSeedResult(
+      List<ThemeBoard> themeBoards,
+      List<Post> posts
+  ) {
+
+  }
+
   private ThemeBoard generateOne(ThemeComponent themeComponent, Post post) {
     return ThemeBoard.builder()
         .post(post)
@@ -37,8 +44,9 @@ public class ThemeBoardSeeder {
   }
 
   @Transactional
-  public List<ThemeBoard> seedData(List<ThemeComponent> themeComponents) {
+  public ThemeBoardSeedResult seedData(List<ThemeComponent> themeComponents) {
     List<ThemeBoard> themeBoards = new ArrayList<>();
+    List<Post> posts = new ArrayList<>();
     int size = themeComponents.size();
     for (int i = 0; i < size; i++) {
       ThemeComponent component = themeComponents.get(i);
@@ -62,10 +70,12 @@ public class ThemeBoardSeeder {
           fileManager.convertUrlToFileName(iconThemeImage.getDesignComponent().getImageUrl()),
           PostType.THEME_BOARD
       );
+      posts.add(post);
       if (!themeBoardRepository.existsByThemeComponentAndPost(component, post)) {
         themeBoards.add(generateOne(component, post));
       }
     }
-    return themeBoardRepository.saveAll(themeBoards);
+    List<ThemeBoard> saved = themeBoardRepository.saveAll(themeBoards);
+    return new ThemeBoardSeedResult(saved, posts);
   }
 }

--- a/src/main/java/com/komentum/seed/seeder/ThemeComponentSeeder.java
+++ b/src/main/java/com/komentum/seed/seeder/ThemeComponentSeeder.java
@@ -14,7 +14,6 @@ import com.komentum.user.domain.User;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,11 +38,9 @@ public class ThemeComponentSeeder {
         .build();
   }
 
-  private List<ThemeImage> seedThemeImages(ThemeComponent themeComponent) {
+  private List<ThemeImage> seedThemeImages(ThemeComponent themeComponent,
+      List<DesignComponent> designComponents) {
     List<ComponentType> componentTypes = componentTypeRepository.findByPlatform(Platform.ANDROID);
-    List<DesignComponent> designComponents = designComponentRepository
-        .findAll(Pageable.ofSize(5))
-        .getContent();
     List<ThemeImage> themeImages = new ArrayList<>();
     for (int i = 0; i < componentTypes.size(); i++) {
       themeImages.add(ThemeImage.builder()
@@ -56,7 +53,8 @@ public class ThemeComponentSeeder {
   }
 
   @Transactional
-  public List<ThemeComponent> seedPerUser(int size, List<User> authors) {
+  public List<ThemeComponent> seedPerUser(int size, List<User> authors,
+      List<DesignComponent> designComponents) {
     List<String> userEmailList = authors.stream()
         .map(User::getUserEmail)
         .toList();
@@ -72,7 +70,7 @@ public class ThemeComponentSeeder {
     }
     themeComponents = themeComponentRepository.saveAll(themeComponents);
     for (ThemeComponent themeComponent : themeComponents) {
-      List<ThemeImage> themeImages = seedThemeImages(themeComponent);
+      List<ThemeImage> themeImages = seedThemeImages(themeComponent, designComponents);
       for (ThemeImage themeImage : themeImages) {
         themeComponent.addThemeImage(themeImage);
       }

--- a/src/main/java/com/komentum/theme/theme/controller/ThemeRetrieveController.java
+++ b/src/main/java/com/komentum/theme/theme/controller/ThemeRetrieveController.java
@@ -89,4 +89,15 @@ public class ThemeRetrieveController {
         userDetails.getUsername());
     return ResponseEntity.ok(res);
   }
+
+  @GetMapping("/bookmarked")
+  @Operation(summary = "인증된 사용자가 현재 북마크한 테마 목록을 조회한다")
+  public ResponseEntity<List<ThemePreviewDto>> findBookmarkedThemes(
+      @PageableDefault(size = 20) @ParameterObject Pageable pageable,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    List<ThemePreviewDto> res = themeRetrieveService.findBookmarkedThemeList(pageable,
+        userDetails.getUsername());
+    return ResponseEntity.ok(res);
+  }
 }

--- a/src/main/java/com/komentum/theme/theme/controller/ThemeRetrieveController.java
+++ b/src/main/java/com/komentum/theme/theme/controller/ThemeRetrieveController.java
@@ -1,6 +1,8 @@
 package com.komentum.theme.theme.controller;
 
+import com.komentum.global.dto.CustomUserDetails;
 import com.komentum.theme.theme.dto.ThemeComponentDto;
+import com.komentum.theme.theme.dto.ThemePreviewDto;
 import com.komentum.theme.theme.service.ThemeRetrieveService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,6 +13,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -74,5 +77,16 @@ public class ThemeRetrieveController {
     List<ThemeComponentDto> completedThemes = themeRetrieveService.getCompletedThemesByUser(
         userEmail, pageable);
     return ResponseEntity.ok(completedThemes);
+  }
+
+  @GetMapping("/popular")
+  @Operation(summary = "인증된 사용자가 인기 테마 목록을 조회한다")
+  public ResponseEntity<List<ThemePreviewDto>> findPopularThemes(
+      @PageableDefault(size = 20) @ParameterObject Pageable pageable,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    List<ThemePreviewDto> res = themeRetrieveService.findPopularThemeList(pageable,
+        userDetails.getUsername());
+    return ResponseEntity.ok(res);
   }
 }

--- a/src/main/java/com/komentum/theme/theme/dto/ThemePreviewDto.java
+++ b/src/main/java/com/komentum/theme/theme/dto/ThemePreviewDto.java
@@ -1,6 +1,7 @@
 package com.komentum.theme.theme.dto;
 
 import com.komentum.theme.theme.domain.ThemeComponent;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,12 +12,18 @@ import lombok.Setter;
 @Setter
 @Builder
 @AllArgsConstructor
+@Schema(description = "테마 미리보기 응답 DTO")
 public class ThemePreviewDto {
 
+  @Schema(description = "테마 식별자")
   private final Integer themeComponentId;
+  @Schema(description = "테마 대표 이미지")
   private final String previewImageUrl;
+  @Schema(description = "테마 이름")
   private final String themeName;
+  @Schema(description = "테마 생성일")
   private final LocalDateTime createdAt;
+  @Schema(description = "테마 갱신일")
   private final LocalDateTime updatedAt;
 
   public static ThemePreviewDto from(ThemeComponent themeComponent, String previewImageUrl) {

--- a/src/main/java/com/komentum/theme/theme/dto/ThemePreviewDto.java
+++ b/src/main/java/com/komentum/theme/theme/dto/ThemePreviewDto.java
@@ -1,0 +1,31 @@
+package com.komentum.theme.theme.dto;
+
+import com.komentum.theme.theme.domain.ThemeComponent;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class ThemePreviewDto {
+
+  private final Integer themeComponentId;
+  private final String previewImageUrl;
+  private final String themeName;
+  private final LocalDateTime createdAt;
+  private final LocalDateTime updatedAt;
+
+  public static ThemePreviewDto from(ThemeComponent themeComponent, String previewImageUrl) {
+    return ThemePreviewDto.builder()
+        .themeComponentId(themeComponent.getThemeComponentId())
+        .previewImageUrl(previewImageUrl)
+        .themeName(themeComponent.getThemeName())
+        .createdAt(themeComponent.getCreatedAt())
+        .updatedAt(themeComponent.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/komentum/theme/theme/dto/ThemePreviewDto.java
+++ b/src/main/java/com/komentum/theme/theme/dto/ThemePreviewDto.java
@@ -6,10 +6,8 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @Schema(description = "테마 미리보기 응답 DTO")

--- a/src/main/java/com/komentum/theme/theme/enums/ThemeSortType.java
+++ b/src/main/java/com/komentum/theme/theme/enums/ThemeSortType.java
@@ -1,0 +1,6 @@
+package com.komentum.theme.theme.enums;
+
+public enum ThemeSortType {
+  PREFER_DESC,
+  CREATED_DESC
+}

--- a/src/main/java/com/komentum/theme/theme/mapper/ThemeComponentMapper.java
+++ b/src/main/java/com/komentum/theme/theme/mapper/ThemeComponentMapper.java
@@ -17,5 +17,7 @@ public interface ThemeComponentMapper {
   @Mapping(target = "isDone", ignore = true)
   @Mapping(target = "themeImages", ignore = true)
   @Mapping(target = "themeStyles", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "updatedAt", ignore = true)
   ThemeComponent convertToTransientEntity(CreateThemeRequest request, String versionNumber);
 }

--- a/src/main/java/com/komentum/theme/theme/repository/ThemeComponentRepositorySupport.java
+++ b/src/main/java/com/komentum/theme/theme/repository/ThemeComponentRepositorySupport.java
@@ -39,7 +39,7 @@ public class ThemeComponentRepositorySupport {
         post,
         prefer
     );
-    BooleanExpression isBookmarked = condition.isBookmarked() ?
+    BooleanExpression isBookmarked = condition.getBookmarked() ?
         postRepositorySupport.isBookmarked(post, client) :
         null;
     return queryFactory.select(themeComponent)

--- a/src/main/java/com/komentum/theme/theme/repository/ThemeComponentRepositorySupport.java
+++ b/src/main/java/com/komentum/theme/theme/repository/ThemeComponentRepositorySupport.java
@@ -1,0 +1,56 @@
+package com.komentum.theme.theme.repository;
+
+import com.komentum.post.domain.QPost;
+import com.komentum.post.domain.QPrefer;
+import com.komentum.post.domain.QThemeBoard;
+import com.komentum.post.repository.PostRepositorySupport;
+import com.komentum.theme.theme.domain.QThemeComponent;
+import com.komentum.theme.theme.domain.ThemeComponent;
+import com.komentum.theme.theme.enums.ThemeSortType;
+import com.komentum.theme.theme.repository.order.ThemeOrder;
+import com.komentum.theme.theme.service.condition.ThemeSearchCondition;
+import com.komentum.user.domain.User;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ThemeComponentRepositorySupport {
+
+  private final JPAQueryFactory queryFactory;
+  private final PostRepositorySupport postRepositorySupport;
+
+  public List<ThemeComponent> findAllThemesByCondition(
+      Pageable pageable,
+      User client,
+      ThemeSearchCondition condition,
+      List<ThemeSortType> sortTypes
+  ) {
+    QThemeComponent themeComponent = QThemeComponent.themeComponent;
+    QThemeBoard themeBoard = QThemeBoard.themeBoard;
+    QPost post = QPost.post;
+    QPrefer prefer = QPrefer.prefer;
+    NumberExpression<Long> preferCount = postRepositorySupport.makePreferCountExpression(
+        post,
+        prefer
+    );
+    BooleanExpression isBookmarked = condition.isBookmarked() ?
+        postRepositorySupport.isBookmarked(post, client) :
+        null;
+    return queryFactory.select(themeComponent)
+        .from(themeBoard)
+        .join(themeBoard.themeComponent, themeComponent)
+        .join(themeBoard.post, post)
+        .where(isBookmarked, themeComponent.isPublic.isTrue())
+        .groupBy(themeComponent.themeComponentId)
+        .orderBy(ThemeOrder.toOrders(sortTypes, themeComponent, preferCount))
+        .limit(pageable.getPageSize())
+        .offset(pageable.getOffset())
+        .fetch();
+  }
+}

--- a/src/main/java/com/komentum/theme/theme/repository/order/ThemeOrder.java
+++ b/src/main/java/com/komentum/theme/theme/repository/order/ThemeOrder.java
@@ -1,0 +1,28 @@
+package com.komentum.theme.theme.repository.order;
+
+import com.komentum.theme.theme.domain.QThemeComponent;
+import com.komentum.theme.theme.enums.ThemeSortType;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.NumberExpression;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ThemeOrder {
+
+  public static OrderSpecifier<?>[] toOrders(List<ThemeSortType> sortTypes,
+      QThemeComponent themeComponent, NumberExpression<Long> preferCount) {
+    List<OrderSpecifier<?>> orders = new ArrayList<>();
+    for (ThemeSortType sortType : sortTypes) {
+      orders.add(switch (sortType) {
+        case PREFER_DESC -> {
+          if (preferCount == null) {
+            throw new IllegalArgumentException("preferCount is null");
+          }
+          yield preferCount.desc();
+        }
+        case CREATED_DESC -> themeComponent.createdAt.desc();
+      });
+    }
+    return orders.toArray(new OrderSpecifier<?>[0]);
+  }
+}

--- a/src/main/java/com/komentum/theme/theme/service/ThemeRetrieveService.java
+++ b/src/main/java/com/komentum/theme/theme/service/ThemeRetrieveService.java
@@ -27,7 +27,6 @@ public class ThemeRetrieveService {
   private final ThemeComponentRepository themeComponentRepository;
   private final ThemeComponentMapper themeComponentMapper;
   private final ThemeImageService themeImageService;
-  private final ThemeImageService themeImageService;
   private final UserEntityFinder userEntityFinder;
   private final ThemeComponentRepositorySupport themeComponentRepositorySupport;
 

--- a/src/main/java/com/komentum/theme/theme/service/ThemeRetrieveService.java
+++ b/src/main/java/com/komentum/theme/theme/service/ThemeRetrieveService.java
@@ -4,9 +4,16 @@ import com.komentum.global.exception.CustomEntityNotFoundException;
 import com.komentum.theme.exception.ResourceNotFoundException;
 import com.komentum.theme.theme.domain.ThemeComponent;
 import com.komentum.theme.theme.dto.ThemeComponentDto;
+import com.komentum.theme.theme.dto.ThemePreviewDto;
+import com.komentum.theme.theme.enums.ThemeSortType;
 import com.komentum.theme.theme.mapper.ThemeComponentMapper;
 import com.komentum.theme.theme.repository.ThemeComponentRepository;
+import com.komentum.theme.theme.repository.ThemeComponentRepositorySupport;
+import com.komentum.theme.theme.service.condition.ThemeSearchCondition;
+import com.komentum.user.domain.User;
+import com.komentum.user.service.UserEntityFinder;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +26,9 @@ public class ThemeRetrieveService {
 
   private final ThemeComponentRepository themeComponentRepository;
   private final ThemeComponentMapper themeComponentMapper;
+  private final ThemeImageService themeImageService;
+  private final UserEntityFinder userEntityFinder;
+  private final ThemeComponentRepositorySupport themeComponentRepositorySupport;
 
   @Transactional(readOnly = true)
   public List<ThemeComponentDto> getAllThemes(Pageable pageable) {
@@ -69,5 +79,29 @@ public class ThemeRetrieveService {
   public ThemeComponent getThemeEntityById(Integer id) {
     return themeComponentRepository.findById(id)
         .orElseThrow(() -> new CustomEntityNotFoundException(ThemeComponent.class, id));
+  }
+
+  @Transactional(readOnly = true)
+  public List<ThemePreviewDto> findPopularThemeList(Pageable pageable, String userIdentifier) {
+    User client = userEntityFinder.findUserEntity(userIdentifier);
+    ThemeSearchCondition condition = new ThemeSearchCondition();
+    List<ThemeComponent> themeComponents = themeComponentRepositorySupport.findAllThemesByCondition(
+        pageable,
+        client,
+        condition,
+        List.of(ThemeSortType.PREFER_DESC)
+    );
+    return toPreviewDto(themeComponents);
+  }
+
+  private List<ThemePreviewDto> toPreviewDto(List<ThemeComponent> themeComponents) {
+    List<Integer> themeIds = themeComponents.stream()
+        .map(ThemeComponent::getThemeComponentId)
+        .toList();
+    Map<Integer, String> themeImageMap = themeImageService.findThemePreviewImages(themeIds);
+    return themeComponents.stream().map(tc -> {
+      String previewImageUrl = themeImageMap.get(tc.getThemeComponentId());
+      return ThemePreviewDto.from(tc, previewImageUrl);
+    }).toList();
   }
 }

--- a/src/main/java/com/komentum/theme/theme/service/ThemeRetrieveService.java
+++ b/src/main/java/com/komentum/theme/theme/service/ThemeRetrieveService.java
@@ -94,6 +94,21 @@ public class ThemeRetrieveService {
     return toPreviewDto(themeComponents);
   }
 
+
+  @Transactional(readOnly = true)
+  public List<ThemePreviewDto> findBookmarkedThemeList(Pageable pageable, String userIdentifier) {
+    User client = userEntityFinder.findUserEntity(userIdentifier);
+    ThemeSearchCondition condition = new ThemeSearchCondition();
+    condition.withBookmarked(true);
+    List<ThemeComponent> themeComponents = themeComponentRepositorySupport.findAllThemesByCondition(
+        pageable,
+        client,
+        condition,
+        List.of(ThemeSortType.CREATED_DESC)
+    );
+    return toPreviewDto(themeComponents);
+  }
+
   private List<ThemePreviewDto> toPreviewDto(List<ThemeComponent> themeComponents) {
     List<Integer> themeIds = themeComponents.stream()
         .map(ThemeComponent::getThemeComponentId)

--- a/src/main/java/com/komentum/theme/theme/service/condition/ThemeSearchCondition.java
+++ b/src/main/java/com/komentum/theme/theme/service/condition/ThemeSearchCondition.java
@@ -1,0 +1,13 @@
+package com.komentum.theme.theme.service.condition;
+
+import lombok.Getter;
+
+@Getter
+public class ThemeSearchCondition {
+
+  private boolean bookmarked;
+
+  public void withBookmarked(Boolean bookmarked) {
+    this.bookmarked = bookmarked;
+  }
+}

--- a/src/main/java/com/komentum/theme/theme/service/condition/ThemeSearchCondition.java
+++ b/src/main/java/com/komentum/theme/theme/service/condition/ThemeSearchCondition.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public class ThemeSearchCondition {
 
-  private boolean bookmarked;
+  private Boolean bookmarked;
 
   public void withBookmarked(Boolean bookmarked) {
     this.bookmarked = bookmarked;

--- a/src/main/java/com/komentum/theme/theme/service/condition/ThemeSearchCondition.java
+++ b/src/main/java/com/komentum/theme/theme/service/condition/ThemeSearchCondition.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public class ThemeSearchCondition {
 
-  private Boolean bookmarked;
+  private Boolean bookmarked = false;
 
   public void withBookmarked(Boolean bookmarked) {
     this.bookmarked = bookmarked;

--- a/src/test/java/com/komentum/catalog/controller/ComponentCatalogControllerTest.java
+++ b/src/test/java/com/komentum/catalog/controller/ComponentCatalogControllerTest.java
@@ -15,6 +15,7 @@ import com.komentum.test.data.scenario.UserScenarioSupport;
 import com.komentum.test.dto.MockMvcRequestDto;
 import com.komentum.test.dto.TestClientDto;
 import com.komentum.test.dto.TestParams;
+import com.komentum.theme.component.domain.DesignComponent;
 import com.komentum.user.domain.User;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -76,10 +77,10 @@ class ComponentCatalogControllerTest {
     List<User> users = userScenarioSupport.builder()
         .withUsers(2)
         .build().users();
-    var dc = designComponentScenarioSupport.builder(users)
+    List<DesignComponent> dc = designComponentScenarioSupport.builder(users)
         .withCountPerUser(3)
-        .build();
-    var tc = themeComponentScenarioSupport.builder(users)
+        .build().designComponents();
+    var tc = themeComponentScenarioSupport.builder(users, dc)
         .withCountPerUser(3)
         .build();
     // given: page=0, size=5로 설정

--- a/src/test/java/com/komentum/test/data/scenario/PostScenarioSupport.java
+++ b/src/test/java/com/komentum/test/data/scenario/PostScenarioSupport.java
@@ -1,16 +1,23 @@
 package com.komentum.test.data.scenario;
 
 import com.komentum.post.domain.Category;
+import com.komentum.post.domain.CategoryPost;
 import com.komentum.post.domain.Post;
 import com.komentum.post.domain.Prefer;
+import com.komentum.post.domain.ThemeBoard;
 import com.komentum.post.domain.enums.PostType;
 import com.komentum.seed.seeder.BookmarkSeeder;
+import com.komentum.seed.seeder.BookmarkSeeder.BookmarkSeedResult;
 import com.komentum.seed.seeder.CategorySeeder;
 import com.komentum.seed.seeder.PostSeeder;
 import com.komentum.seed.seeder.PreferSeeder;
+import com.komentum.seed.seeder.ThemeBoardSeeder;
+import com.komentum.seed.seeder.ThemeBoardSeeder.ThemeBoardSeedResult;
 import com.komentum.seed.seeder.UserSeeder;
+import com.komentum.theme.theme.domain.ThemeComponent;
 import com.komentum.user.domain.User;
 import java.util.List;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,9 +35,14 @@ public class PostScenarioSupport {
   private final PreferSeeder preferSeeder;
   private final CategorySeeder categorySeeder;
   private final BookmarkSeeder bookmarkSeeder;
+  private final ThemeBoardSeeder themeBoardSeeder;
 
   public PostScenarioBuilder builder() {
     return new PostScenarioBuilder();
+  }
+
+  public PostScenarioBuilder builder(List<User> users) {
+    return new PostScenarioBuilder(users);
   }
 
   /**
@@ -41,7 +53,9 @@ public class PostScenarioSupport {
       List<Post> posts,
       List<Prefer> prefers,
       List<Category> categories,
-      List<Category> bookmarks
+      List<Category> bookmarks,
+      List<CategoryPost> bookmarkMappings,
+      List<ThemeBoard> themeBoards
   ) {
 
     public User getFirstUser() {
@@ -52,6 +66,7 @@ public class PostScenarioSupport {
   /**
    * 게시글 관련 테스트 데이터 생성 시나리오를 조합하는 클래스
    * */
+  @NoArgsConstructor
   public class PostScenarioBuilder {
 
     private List<User> users;
@@ -59,6 +74,12 @@ public class PostScenarioSupport {
     private List<Prefer> prefers;
     private List<Category> categories;
     private List<Category> bookmarks;
+    private List<CategoryPost> bookmarkMappings;
+    private List<ThemeBoard> themeBoards;
+
+    public PostScenarioBuilder(List<User> users) {
+      this.users = users;
+    }
 
     /**
      * userCount 수의 user Entity 생성
@@ -73,6 +94,7 @@ public class PostScenarioSupport {
      * user마다 postPerUser만큼의 "ThemeBoard 성격의 Post" 생성
      * todo : 추후 ThemeBoard 생성 로직으로 대체해야함 ( 우선순위 높음 )
      * */
+    @Deprecated
     @Transactional
     public PostScenarioBuilder withThemeBoardPerUser(int postPerUser) {
       if (users.isEmpty()) {
@@ -80,6 +102,17 @@ public class PostScenarioSupport {
       }
       posts = postSeeder
           .seedPerUser(users, postPerUser, "https://test-data.com", PostType.THEME_BOARD);
+      return this;
+    }
+
+    @Transactional
+    public PostScenarioBuilder withThemeBoards(List<ThemeComponent> themeComponents) {
+      if (users.isEmpty()) {
+        throw new RuntimeException("user must not be empty");
+      }
+      ThemeBoardSeedResult result = themeBoardSeeder.seedData(themeComponents);
+      this.posts = result.posts();
+      this.themeBoards = result.themeBoards();
       return this;
     }
 
@@ -91,7 +124,19 @@ public class PostScenarioSupport {
       if (users.isEmpty() || posts.isEmpty()) {
         throw new RuntimeException("user or post must not be empty");
       }
-      this.prefers = preferSeeder.seedPerPost(preferPerPost, users);
+      this.prefers = preferSeeder.seedPerPost(preferPerPost, users, 1);
+      return this;
+    }
+
+    /**
+     * 게시글 중 일부(ratio)에 preferPerPost 만큼의 prefer 생성
+     */
+    @Transactional
+    public PostScenarioBuilder withPrefersPerPost(int preferPerPost, double ratio) {
+      if (users.isEmpty() || posts == null || posts.isEmpty()) {
+        throw new RuntimeException("user or post must not be empty");
+      }
+      this.prefers = preferSeeder.seedPerPost(preferPerPost, users, ratio);
       return this;
     }
 
@@ -128,12 +173,15 @@ public class PostScenarioSupport {
       if (bookmarkRatio < 0 || bookmarkRatio > 1) {
         throw new IllegalArgumentException("bookmarkRatio must be between 0 and 1");
       }
-      this.bookmarks = bookmarkSeeder.bookmarkByRatio(users, posts, bookmarkRatio);
+      BookmarkSeedResult result = bookmarkSeeder.bookmarkByRatio(users, posts, bookmarkRatio);
+      bookmarks = result.bookmarks();
+      bookmarkMappings = result.bookmarkMappings();
       return this;
     }
 
     public Result build() {
-      return new Result(users, posts, prefers, categories, bookmarks);
+      return new Result(users, posts, prefers, categories, bookmarks, bookmarkMappings,
+          themeBoards);
     }
   }
 }

--- a/src/test/java/com/komentum/test/data/scenario/ThemeComponentScenarioSupport.java
+++ b/src/test/java/com/komentum/test/data/scenario/ThemeComponentScenarioSupport.java
@@ -1,6 +1,7 @@
 package com.komentum.test.data.scenario;
 
 import com.komentum.seed.seeder.ThemeComponentSeeder;
+import com.komentum.theme.component.domain.DesignComponent;
 import com.komentum.theme.component.service.ColorStyleSeeder;
 import com.komentum.theme.component.service.ComponentTypeSeeder;
 import com.komentum.theme.theme.domain.ThemeComponent;
@@ -23,17 +24,21 @@ public class ThemeComponentScenarioSupport {
 
   }
 
-  public ThemeComponentScenarioBuilder builder(List<User> users) {
-    return new ThemeComponentScenarioBuilder().builder(users);
+  public ThemeComponentScenarioBuilder builder(List<User> users,
+      List<DesignComponent> designComponents) {
+    return new ThemeComponentScenarioBuilder().builder(users, designComponents);
   }
 
   public class ThemeComponentScenarioBuilder {
 
     private List<User> users;
     private int countPerUser;
+    private List<DesignComponent> designComponents;
 
-    public ThemeComponentScenarioBuilder builder(List<User> users) {
+    public ThemeComponentScenarioBuilder builder(List<User> users,
+        List<DesignComponent> designComponents) {
       this.users = users;
+      this.designComponents = designComponents;
       return this;
     }
 
@@ -50,7 +55,8 @@ public class ThemeComponentScenarioSupport {
       if (countPerUser <= 0) {
         throw new IllegalArgumentException("countPerUser must be bigger than 0");
       }
-      List<ThemeComponent> themeComponents = themeComponentSeeder.seedPerUser(countPerUser, users);
+      List<ThemeComponent> themeComponents = themeComponentSeeder.seedPerUser(countPerUser, users,
+          designComponents);
       // convert data to result
       return new ThemeComponentScenarioResult(themeComponents);
     }

--- a/src/test/java/com/komentum/theme/controller/ThemeRetrieveControllerTest.java
+++ b/src/test/java/com/komentum/theme/controller/ThemeRetrieveControllerTest.java
@@ -1,22 +1,40 @@
 package com.komentum.theme.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.komentum.global.utils.FileManager;
+import com.komentum.post.domain.ThemeBoard;
 import com.komentum.test.MockMvcUtils;
 import com.komentum.test.config.EnableTestProfile;
+import com.komentum.test.data.TestDataRemover;
 import com.komentum.test.data.ThemeDataGenerator;
 import com.komentum.test.data.UserDataGenerator;
+import com.komentum.test.data.scenario.DesignComponentScenarioSupport;
+import com.komentum.test.data.scenario.PostScenarioSupport;
+import com.komentum.test.data.scenario.ThemeComponentScenarioSupport;
+import com.komentum.test.data.scenario.UserScenarioSupport;
+import com.komentum.test.dto.MockMvcRequestDto;
 import com.komentum.test.dto.TestClientDto;
+import com.komentum.theme.component.domain.DesignComponent;
 import com.komentum.theme.theme.domain.ThemeComponent;
+import com.komentum.theme.theme.dto.ThemePreviewDto;
 import com.komentum.user.domain.User;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -36,10 +54,35 @@ class ThemeRetrieveControllerTest {
   private UserDataGenerator userDataGenerator;
 
   @Autowired
+  private TestDataRemover testDataRemover;
+
+  @Autowired
   private MockMvcUtils mockMvcUtils;
+
+  @Autowired
+  private ThemeComponentScenarioSupport themeComponentScenarioSupport;
+
+  @Autowired
+  private PostScenarioSupport postScenarioSupport;
+
+  @Autowired
+  private UserScenarioSupport userScenarioSupport;
+
+  @Autowired
+  private DesignComponentScenarioSupport designComponentScenarioSupport;
+
+  @Autowired
+  private FileManager fileManager;
 
   private TestClientDto testClient;
 
+  private void assertThemePreviewDto(ThemePreviewDto themePreviewDto) {
+    assertThat(themePreviewDto.getThemeComponentId()).isNotNull();
+    assertThat(themePreviewDto.getThemeName()).isNotBlank();
+    assertThat(themePreviewDto.getPreviewImageUrl()).isNotBlank();
+    assertThat(themePreviewDto.getCreatedAt()).isNotNull();
+    assertThat(themePreviewDto.getUpdatedAt()).isNotNull();
+  }
 
   @BeforeEach
   void setUp() {
@@ -51,8 +94,7 @@ class ThemeRetrieveControllerTest {
 
   @AfterEach
   void tearDown() {
-    themeDataGenerator.deleteTestData();
-    userDataGenerator.deleteAllUsers();
+    testDataRemover.deleteAll();
   }
 
   @Test
@@ -161,5 +203,126 @@ class ThemeRetrieveControllerTest {
     // then
     mockMvc.perform(requestBuilder)
         .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("when send request, retrieve themes order by prefers")
+  public void findPopularThemes_success() throws Exception {
+    // 임시 : setUp 데이터 삭제 ( 시나리오 구현 어려움 )
+    testDataRemover.deleteAll();
+    // stub : 이미지 생성 시 Mock URL 사용
+    Mockito.when(fileManager.resolveFilePath(Mockito.any()))
+        .thenReturn("http://mocked-url/1234567890");
+    // given: 사용자 4명 생성
+    List<User> users = userScenarioSupport.builder()
+        .withUsers(4)
+        .build().users();
+    // given : design component 4개 생성
+    List<DesignComponent> designComponents = designComponentScenarioSupport.builder(users)
+        .withCountPerUser(1)
+        .build().designComponents();
+    // given: theme 4개 생성
+    List<ThemeComponent> themeComponents = themeComponentScenarioSupport.builder(users,
+            designComponents)
+        .withCountPerUser(1)
+        .build().themeComponents();
+    // given: theme board를 4개 생성하고, 그 중 2개는 4개의 좋아요를 갖는다
+    var postResult = postScenarioSupport.builder(users)
+        .withThemeBoards(themeComponents)
+        .withPrefersPerPost(4, 0.5)
+        .build();
+    // when
+    User client = users.get(0);
+    List<ThemePreviewDto> response = mockMvcUtils.doAuthRequest(
+        MockMvcRequestDto.<Void, List<ThemePreviewDto>>builder()
+            .mockMvc(mockMvc)
+            .path("/api/themes/popular")
+            .httpMethod(HttpMethod.GET)
+            .clientDto(TestClientDto.fromEntity(client))
+            .statusCode(200)
+            .responseType(new TypeReference<>() {
+            })
+            .build()
+    );
+    // then
+    Map<Long, Long> preferCountByPost = postResult.prefers().stream()
+        .collect(Collectors.groupingBy(
+            p -> p.getPost().getPostId(),
+            Collectors.counting()
+        ));
+    Map<Integer, Long> preferCountByTheme = postResult.themeBoards().stream()
+        .collect(Collectors.groupingBy(
+            tb -> tb.getThemeComponent().getThemeComponentId(),
+            Collectors.summingLong(
+                tb -> preferCountByPost.getOrDefault(
+                    tb.getPost().getPostId(),
+                    0L
+                )
+            )
+        ));
+    for (int i = 0; i < 2; i++) {
+      assertThemePreviewDto(response.get(i));
+      assertThat(preferCountByTheme.get(response.get(i).getThemeComponentId())).isEqualTo(4);
+    }
+    for (int i = 2; i < 4; i++) {
+      assertThemePreviewDto(response.get(i));
+      assertThat(preferCountByTheme.get(response.get(i).getThemeComponentId())).isEqualTo(0);
+    }
+  }
+
+  @Test
+  @DisplayName("when send request, retrieve themes that user bookmarked")
+  public void findBookmarkedThemes_success() throws Exception {
+    // 임시 : setUp 데이터 삭제 ( 시나리오 구현 어려움 )
+    testDataRemover.deleteAll();
+    // stub : 이미지 생성 시 Mock URL 사용
+    Mockito.when(fileManager.resolveFilePath(Mockito.any()))
+        .thenReturn("http://mocked-url/1234567890");
+    // given: 사용자 4명 생성
+    List<User> users = userScenarioSupport.builder()
+        .withUsers(4)
+        .build().users();
+    // given : design component 4개 생성
+    List<DesignComponent> designComponents = designComponentScenarioSupport.builder(users)
+        .withCountPerUser(1)
+        .build().designComponents();
+    // given: theme 4개 생성
+    List<ThemeComponent> themeComponents = themeComponentScenarioSupport.builder(users,
+            designComponents)
+        .withCountPerUser(1)
+        .build().themeComponents();
+    // given: theme board를 4개 생성하고, 그 중 2개를 저장한다
+    var postResult = postScenarioSupport.builder(users)
+        .withThemeBoards(themeComponents)
+        .withBookmarkRatio(0.5)
+        .build();
+    // when
+    User client = users.get(0);
+    List<ThemePreviewDto> response = mockMvcUtils.doAuthRequest(
+        MockMvcRequestDto.<Void, List<ThemePreviewDto>>builder()
+            .mockMvc(mockMvc)
+            .path("/api/themes/bookmarked")
+            .httpMethod(HttpMethod.GET)
+            .clientDto(TestClientDto.fromEntity(client))
+            .statusCode(200)
+            .responseType(new TypeReference<>() {
+            })
+            .build()
+    );
+    // then: 응답 데이터 크기 검증
+    Set<Long> bookmarkedPostIdSet = postResult.bookmarkMappings().stream()
+        .map(bm -> bm.getPost().getPostId())
+        .collect(Collectors.toSet());
+    Set<Integer> bookmarkedThemeIdSet = postResult.themeBoards().stream()
+        .filter(tb -> bookmarkedPostIdSet.contains(tb.getPost().getPostId()))
+        .map(ThemeBoard::getThemeComponent)
+        .map(ThemeComponent::getThemeComponentId)
+        .collect(Collectors.toSet());
+    assertThat(response).hasSize(bookmarkedThemeIdSet.size());
+    // then: 응답 데이터의 각 테마가 실제로 북마크 되어있는지 검증
+    assertThat(response).allSatisfy(dto -> {
+      assertThat(bookmarkedThemeIdSet).contains(dto.getThemeComponentId());
+      assertThemePreviewDto(dto);
+    });
   }
 }


### PR DESCRIPTION
## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용
- 인기 테마 목록 조회 API 구현
- 북마크한 테마 목록 조회 API 구현
- seeder에서 도메인 간 의존 제거 및 응답 구조 변경

관련 이슈: #100 

## 테스트 결과

### 1. 통합 테스트 결과
<img width="1247" height="657" alt="image" src="https://github.com/user-attachments/assets/0ce5e6de-63d7-4acf-bb76-c16f211b93e9" />
<img width="1299" height="698" alt="image" src="https://github.com/user-attachments/assets/bbbdb745-8430-4697-896e-8edd7fb2ef9a" />

### 2. 수동 테스트 결과 ( 북마크 후 테마 목록 조회 )
<img width="1265" height="496" alt="image" src="https://github.com/user-attachments/assets/755eba8b-8da9-4d11-9932-14dad518b881" />

### 3. 수동 테스트 결과 ( 51번 테마 게시글(51번 테마) 좋아요 후, 좋아요 순으로 테마 목록 조회 ) 
<img width="1260" height="474" alt="image" src="https://github.com/user-attachments/assets/86c90d59-4d09-4527-9f71-bb2f37d0fb4b" />


## PR 체크리스트
- [ ] 커밋 메시지가 가이드라인을 따르는가
- [ ] 테스트 코드를 모두 통과하였는가
- [ ] 관련 이슈를 연결하였는가
