### PR TITLE
Feat/#106 add component type to design component

### DIFF
--- a/src/main/java/com/komentum/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/komentum/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.server.ResponseStatusException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -40,6 +41,14 @@ public class GlobalExceptionHandler {
     Map<String, String> errors = new HashMap<>();
     errors.put("message", ex.getMessage());
     return new ResponseEntity<>(errors, HttpStatus.FORBIDDEN);
+  }
+
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<Map<String, String>> handleResponseStatusException(
+      ResponseStatusException ex) {
+    Map<String, String> errors = new HashMap<>();
+    errors.put("message", ex.getReason());
+    return new ResponseEntity<>(errors, ex.getStatusCode());
   }
 
   @ExceptionHandler(Exception.class)

--- a/src/main/java/com/komentum/theme/component/controller/DesignComponentController.java
+++ b/src/main/java/com/komentum/theme/component/controller/DesignComponentController.java
@@ -19,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -46,7 +45,7 @@ public class DesignComponentController {
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   @Operation(summary = "현재 인증된 사용자가 DesignComponent를 생성한다.")
   public ResponseEntity<DesignComponentDto> createDesignComponent(
-      @Valid @ModelAttribute CreateDesignComponentRequest request,
+      @Valid @RequestPart("request") CreateDesignComponentRequest request,
       @RequestPart("image") MultipartFile image,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     DesignComponentDto saved = designComponentFacade.createDesignComponent(request, image,
@@ -100,7 +99,7 @@ public class DesignComponentController {
   @Operation(summary = "현재 인증된 사용자가 자신이 소유한 ID = id인 designComponent를 수정한다.")
   public ResponseEntity<DesignComponentDto> updateDesignComponent(
       @PathVariable("id") Integer id,
-      @ModelAttribute @Valid UpdateDesignComponentRequest request,
+      @RequestPart("request") @Valid UpdateDesignComponentRequest request,
       @RequestPart(value = "image", required = false) MultipartFile image) {
     DesignComponentDto updated = designComponentFacade.updateDesignComponent(id, request, image);
     return ResponseEntity.ok(updated);

--- a/src/main/java/com/komentum/theme/component/domain/DesignComponent.java
+++ b/src/main/java/com/komentum/theme/component/domain/DesignComponent.java
@@ -1,6 +1,7 @@
 package com.komentum.theme.component.domain;
 
 import com.komentum.user.domain.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,8 +10,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,6 +43,10 @@ public class DesignComponent {
   @Column(name = "is_public")
   private Boolean isPublic;
 
+  @Builder.Default
+  @OneToMany(mappedBy = "designComponent", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<DesignComponentComponentType> componentTypeMappings = new ArrayList<>();
+
   @CreationTimestamp
   @Column(updatable = false)
   private LocalDateTime createdAt;
@@ -52,6 +60,22 @@ public class DesignComponent {
     }
     if (isPublic != null) {
       this.isPublic = isPublic;
+    }
+  }
+
+  public List<ComponentType> getComponentTypes() {
+    return componentTypeMappings.stream()
+        .map(DesignComponentComponentType::getComponentType)
+        .toList();
+  }
+
+  public void replaceComponentTypes(List<ComponentType> componentTypes) {
+    this.componentTypeMappings.clear();
+    if (componentTypes == null) {
+      return;
+    }
+    for (ComponentType componentType : componentTypes) {
+      this.componentTypeMappings.add(DesignComponentComponentType.of(this, componentType));
     }
   }
 }

--- a/src/main/java/com/komentum/theme/component/domain/DesignComponentComponentType.java
+++ b/src/main/java/com/komentum/theme/component/domain/DesignComponentComponentType.java
@@ -1,0 +1,49 @@
+package com.komentum.theme.component.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "design_component_component_type", uniqueConstraints = {
+    @UniqueConstraint(name = "uk_design_component_component_type", columnNames = {
+        "design_component_id", "component_type_id"
+    })
+})
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DesignComponentComponentType {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer designComponentComponentTypeId;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "design_component_id", nullable = false)
+  private DesignComponent designComponent;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "component_type_id", nullable = false)
+  private ComponentType componentType;
+
+  public static DesignComponentComponentType of(DesignComponent designComponent,
+      ComponentType componentType) {
+    return DesignComponentComponentType.builder()
+        .designComponent(designComponent)
+        .componentType(componentType)
+        .build();
+  }
+}

--- a/src/main/java/com/komentum/theme/component/dto/CreateDesignComponentRequest.java
+++ b/src/main/java/com/komentum/theme/component/dto/CreateDesignComponentRequest.java
@@ -1,6 +1,9 @@
 package com.komentum.theme.component.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,4 +20,11 @@ public class CreateDesignComponentRequest {
 
   @Schema(description = "공개 여부", example = "true")
   private Boolean isPublic;
+
+
+  // when create, auto match
+  @NotNull(message = "componentTypeIds is required")
+  @Size(min = 1, message = "componentTypeIds must contain at least one id")
+  @Schema(description = "디자인 컴포넌트에 연결할 component type id 목록", example = "[1,2,3]")
+  private List<@NotNull(message = "componentTypeIds cannot contain null") Integer> componentTypeIds;
 }

--- a/src/main/java/com/komentum/theme/component/dto/DesignComponentDto.java
+++ b/src/main/java/com/komentum/theme/component/dto/DesignComponentDto.java
@@ -3,6 +3,7 @@ package com.komentum.theme.component.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,4 +39,8 @@ public class DesignComponentDto {
   @Schema(description = "공개 여부", example = "true")
   @JsonProperty("is_public")
   private Boolean isPublic;
+
+  @Schema(description = "연결된 component type 목록")
+  @JsonProperty("component_types")
+  private List<ComponentTypeDto> componentTypes;
 }

--- a/src/main/java/com/komentum/theme/component/dto/UpdateDesignComponentRequest.java
+++ b/src/main/java/com/komentum/theme/component/dto/UpdateDesignComponentRequest.java
@@ -6,7 +6,8 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+@Getter
+@Setter
 import lombok.NoArgsConstructor;
 
 @Data

--- a/src/main/java/com/komentum/theme/component/dto/UpdateDesignComponentRequest.java
+++ b/src/main/java/com/komentum/theme/component/dto/UpdateDesignComponentRequest.java
@@ -1,6 +1,9 @@
 package com.komentum.theme.component.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,4 +19,8 @@ public class UpdateDesignComponentRequest {
 
   @Schema(description = "공개 여부", example = "true")
   private Boolean isPublic;
+
+  @Size(min = 1, message = "componentTypeIds must contain at least one id")
+  @Schema(description = "component type id 목록. 전달 시 기존 목록을 전체 교체한다.", example = "[1,2,3]")
+  private List<@NotNull(message = "componentTypeIds cannot contain null") Integer> componentTypeIds;
 }

--- a/src/main/java/com/komentum/theme/component/dto/UpdateDesignComponentRequest.java
+++ b/src/main/java/com/komentum/theme/component/dto/UpdateDesignComponentRequest.java
@@ -6,11 +6,12 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 @Getter
 @Setter
-import lombok.NoArgsConstructor;
-
-@Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/komentum/theme/component/mapper/DesignComponentMapper.java
+++ b/src/main/java/com/komentum/theme/component/mapper/DesignComponentMapper.java
@@ -8,15 +8,17 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 // DesignComponent Mapper
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = ComponentTypeMapper.class)
 public interface DesignComponentMapper {
 
   @Mapping(target = "publicUserId", source = "user.publicUserId")
+  @Mapping(target = "componentTypes", source = "componentTypes")
   DesignComponentDto toDto(DesignComponent designComponent);
 
   @Mapping(target = "designComponentId", ignore = true)
   @Mapping(target = "createdAt", ignore = true)
   @Mapping(target = "updatedAt", ignore = true)
+  @Mapping(target = "componentTypeMappings", ignore = true)
   @Mapping(target = "user", source = "user")
   @Mapping(target = "imageUrl", source = "imageUrl")
   DesignComponent toEntity(CreateDesignComponentRequest request, String imageUrl, User user);

--- a/src/main/java/com/komentum/theme/component/repository/ComponentTypeRepository.java
+++ b/src/main/java/com/komentum/theme/component/repository/ComponentTypeRepository.java
@@ -2,7 +2,6 @@ package com.komentum.theme.component.repository;
 
 import com.komentum.theme.component.domain.ComponentType;
 import com.komentum.theme.component.enums.Platform;
-import java.util.List;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/komentum/theme/component/repository/DesignComponentRepository.java
+++ b/src/main/java/com/komentum/theme/component/repository/DesignComponentRepository.java
@@ -2,14 +2,28 @@ package com.komentum.theme.component.repository;
 
 import com.komentum.theme.component.domain.DesignComponent;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DesignComponentRepository extends JpaRepository<DesignComponent, Integer> {
 
+  @EntityGraph(attributePaths = {"user", "componentTypeMappings", "componentTypeMappings.componentType"})
+  Optional<DesignComponent> findByDesignComponentId(Integer designComponentId);
+
+  @Query("select dc.designComponentId from DesignComponent dc")
+  Page<Integer> findDesignComponentIdPage(Pageable pageable);
+
+  @EntityGraph(attributePaths = {"user", "componentTypeMappings", "componentTypeMappings.componentType"})
+  List<DesignComponent> findByDesignComponentIdIn(List<Integer> designComponentIds);
+
+  @EntityGraph(attributePaths = {"user", "componentTypeMappings", "componentTypeMappings.componentType"})
   List<DesignComponent> findByUser_PublicUserId(String userPublicUserId);
 
   List<DesignComponent> findByUser_UserEmailIn(List<String> userEmails);
 }
-

--- a/src/main/java/com/komentum/theme/component/service/DesignComponentService.java
+++ b/src/main/java/com/komentum/theme/component/service/DesignComponentService.java
@@ -1,32 +1,46 @@
 package com.komentum.theme.component.service;
 
 import com.komentum.global.utils.FileManager;
+import com.komentum.theme.component.domain.ComponentType;
 import com.komentum.theme.component.domain.DesignComponent;
 import com.komentum.theme.component.domain.policy.DesignComponentPolicy;
 import com.komentum.theme.component.dto.CreateDesignComponentRequest;
 import com.komentum.theme.component.dto.DesignComponentDto;
 import com.komentum.theme.component.dto.UpdateDesignComponentRequest;
 import com.komentum.theme.component.mapper.DesignComponentMapper;
+import com.komentum.theme.component.repository.ComponentTypeRepository;
 import com.komentum.theme.component.repository.DesignComponentRepository;
 import com.komentum.theme.exception.ResourceNotFoundException;
 import com.komentum.user.domain.User;
 import java.io.IOException;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class DesignComponentService {
 
   private final DesignComponentRepository designComponentRepository;
+  private final ComponentTypeRepository componentTypeRepository;
   private final DesignComponentPolicy designComponentPolicy;
   private final DesignComponentMapper mapper;
   private final FileManager fileManager;
@@ -35,9 +49,17 @@ public class DesignComponentService {
   public DesignComponentDto createDesignComponent(CreateDesignComponentRequest request,
       MultipartFile image,
       User user) {
+    List<ComponentType> componentTypes = resolveComponentTypes(request.getComponentTypeIds());
     String imageUrl = uploadImage(image);
-    DesignComponent newComponent = mapper.toEntity(request, imageUrl, user);
-    return mapper.toDto(designComponentRepository.save(newComponent));
+
+    try {
+      DesignComponent newComponent = mapper.toEntity(request, imageUrl, user);
+      newComponent.replaceComponentTypes(componentTypes);
+      return mapper.toDto(designComponentRepository.saveAndFlush(newComponent));
+    } catch (RuntimeException e) {
+      deleteUploadedImageQuietly(imageUrl);
+      throw e;
+    }
   }
 
   // READ
@@ -49,7 +71,7 @@ public class DesignComponentService {
 
   @Transactional(readOnly = true)
   public DesignComponent getEntityById(Integer id) {
-    return designComponentRepository.findById(id)
+    return designComponentRepository.findByDesignComponentId(id)
         .orElseThrow(
             () -> new ResourceNotFoundException("DesignComponent not found with id: " + id));
   }
@@ -63,8 +85,24 @@ public class DesignComponentService {
   // 페이지네이션 지원 메서드 (새로 추가)
   @Transactional(readOnly = true)
   public Page<DesignComponentDto> getAllDesignComponents(Pageable pageable) {
-    return designComponentRepository.findAll(pageable)
-        .map(mapper::toDto);
+    Page<Integer> designComponentIdPage = designComponentRepository.findDesignComponentIdPage(
+        pageable);
+    if (designComponentIdPage.isEmpty()) {
+      return new PageImpl<>(List.of(), pageable, designComponentIdPage.getTotalElements());
+    }
+
+    List<Integer> designComponentIds = designComponentIdPage.getContent();
+    Map<Integer, DesignComponent> componentMap = designComponentRepository
+        .findByDesignComponentIdIn(designComponentIds).stream()
+        .collect(Collectors.toMap(DesignComponent::getDesignComponentId, Function.identity()));
+
+    List<DesignComponentDto> content = designComponentIds.stream()
+        .map(componentMap::get)
+        .filter(Objects::nonNull)
+        .map(mapper::toDto)
+        .toList();
+
+    return new PageImpl<>(content, pageable, designComponentIdPage.getTotalElements());
   }
 
   // UPDATE
@@ -77,11 +115,24 @@ public class DesignComponentService {
       throw new AccessDeniedException("failed to update designComponent : invalid user or role");
     }
 
+    List<ComponentType> componentTypes = null;
+    if (request.getComponentTypeIds() != null) {
+      componentTypes = resolveComponentTypes(request.getComponentTypeIds());
+    }
+
     String imageUrl = (image != null) ? uploadImage(image) : null;
 
-    component.update(imageUrl, request.getIsPublic()
-    );
-    return mapper.toDto(component);
+    try {
+      component.update(imageUrl, request.getIsPublic());
+      if (componentTypes != null) {
+        component.replaceComponentTypes(componentTypes);
+      }
+      designComponentRepository.flush();
+      return mapper.toDto(component);
+    } catch (RuntimeException e) {
+      deleteUploadedImageQuietly(imageUrl);
+      throw e;
+    }
   }
 
   // DELETE
@@ -105,5 +156,63 @@ public class DesignComponentService {
 
   }
 
+  private void deleteUploadedImageQuietly(String imageUrl) {
+    if (imageUrl == null) {
+      return;
+    }
+    try {
+      fileManager.deleteFile(fileManager.convertUrlToFileName(imageUrl));
+    } catch (RuntimeException e) {
+      log.warn("failed to cleanup uploaded image after rollback: {}", imageUrl, e);
+    }
+  }
+
+  /**
+   * 입력된 componentsTypeIds 를 검증하고 정규화, 엔티티 변환한다.
+   *
+   * @param requestedIds
+   * @return
+   */
+  private List<ComponentType> resolveComponentTypes(List<Integer> requestedIds) {
+    validateDuplicateComponentTypeIds(requestedIds);
+    LinkedHashSet<Integer> uniqueRequestedIds = new LinkedHashSet<>(requestedIds);
+    List<ComponentType> componentTypes = componentTypeRepository.findAllById(uniqueRequestedIds);
+
+    Set<Integer> foundIds = componentTypes.stream()
+        .map(ComponentType::getComponentTypeId)
+        .collect(Collectors.toSet());
+    List<Integer> missingIds = uniqueRequestedIds.stream()
+        .filter(id -> !foundIds.contains(id))
+        .toList();
+    if (!missingIds.isEmpty()) {
+      throw new ResourceNotFoundException("ComponentType not found with ids: " + missingIds);
+    }
+
+    Map<Integer, ComponentType> componentTypeMap = componentTypes.stream()
+        .collect(Collectors.toMap(ComponentType::getComponentTypeId, Function.identity()));
+    return uniqueRequestedIds.stream()
+        .map(componentTypeMap::get)
+        .toList();
+  }
+
+  /**
+   * componentType의 중복 검증
+   *
+   * @param requestedIds
+   */
+  private void validateDuplicateComponentTypeIds(List<Integer> requestedIds) {
+    // 이미 처리한 id 집합
+    Set<Integer> seen = new LinkedHashSet<>();
+    List<Integer> duplicateIds = requestedIds.stream()
+        .filter(id -> !seen.add(id))
+        .distinct()
+        .toList();
+    if (!duplicateIds.isEmpty()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "Duplicate componentTypeIds are not allowed: " + duplicateIds
+      );
+    }
+  }
 
 }

--- a/src/test/java/com/komentum/test/data/DesignComponentDataGenerator.java
+++ b/src/test/java/com/komentum/test/data/DesignComponentDataGenerator.java
@@ -1,6 +1,7 @@
 package com.komentum.test.data;
 
 import com.github.javafaker.Faker;
+import com.komentum.theme.component.domain.ComponentType;
 import com.komentum.theme.component.domain.DesignComponent;
 import com.komentum.theme.component.repository.DesignComponentRepository;
 import com.komentum.user.domain.User;
@@ -46,14 +47,21 @@ public class DesignComponentDataGenerator {
    * @return 생성된 DesignComponent 리스트
    */
   public List<DesignComponent> generateDesignComponents(List<User> users, int componentPerUser) {
+    return generateDesignComponents(users, componentPerUser, List.of());
+  }
+
+  public List<DesignComponent> generateDesignComponents(List<User> users, int componentPerUser,
+      List<ComponentType> componentTypes) {
     List<DesignComponent> components = new ArrayList<>();
     for (User user : users) {
       for (int j = 0; j < componentPerUser; j++) {
-        components.add(DesignComponent.builder()
+        DesignComponent designComponent = DesignComponent.builder()
             .user(user)
             .imageUrl(faker.internet().image())
             .isPublic(j % 2 == 0) // 짝수일 때는 public 홀수일때는 private
-            .build());
+            .build();
+        designComponent.replaceComponentTypes(componentTypes);
+        components.add(designComponent);
       }
     }
     return designComponentRepository.saveAll(components);
@@ -69,11 +77,18 @@ public class DesignComponentDataGenerator {
    * @return 생성된 DesignComponent
    */
   public DesignComponent generateDesignComponent(User user, String imageUrl, Boolean isPublic) {
-    return designComponentRepository.save(DesignComponent.builder()
+    return generateDesignComponent(user, imageUrl, isPublic, List.of());
+  }
+
+  public DesignComponent generateDesignComponent(User user, String imageUrl, Boolean isPublic,
+      List<ComponentType> componentTypes) {
+    DesignComponent designComponent = DesignComponent.builder()
         .user(user)
         .imageUrl(imageUrl)
         .isPublic(isPublic)
-        .build());
+        .build();
+    designComponent.replaceComponentTypes(componentTypes);
+    return designComponentRepository.save(designComponent);
   }
 
   /**
@@ -83,7 +98,7 @@ public class DesignComponentDataGenerator {
    * @return 생성된 DesignComponent
    */
   public DesignComponent generateDesignComponent(User user) {
-    return generateDesignComponent(user, faker.internet().image(), true);
+    return generateDesignComponent(user, faker.internet().image(), true, List.of());
   }
 
 

--- a/src/test/java/com/komentum/theme/controller/DesignComponentControllerTest.java
+++ b/src/test/java/com/komentum/theme/controller/DesignComponentControllerTest.java
@@ -3,13 +3,15 @@ package com.komentum.theme.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.komentum.global.dto.CustomUserDetails;
 import com.komentum.global.security.UserRole;
@@ -17,13 +19,18 @@ import com.komentum.global.utils.FileManager;
 import com.komentum.test.MockMvcUtils;
 import com.komentum.test.data.DesignComponentDataGenerator;
 import com.komentum.test.data.UserDataGenerator;
+import com.komentum.test.dto.MockMvcMultipartRequestDto;
 import com.komentum.test.dto.TestClientDto;
+import com.komentum.theme.component.domain.ComponentType;
 import com.komentum.theme.component.domain.DesignComponent;
 import com.komentum.theme.component.dto.CreateDesignComponentRequest;
 import com.komentum.theme.component.dto.DesignComponentDto;
 import com.komentum.theme.component.dto.UpdateDesignComponentRequest;
+import com.komentum.theme.component.enums.Platform;
+import com.komentum.theme.component.repository.ComponentTypeRepository;
 import com.komentum.theme.component.repository.DesignComponentRepository;
 import com.komentum.user.domain.User;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +40,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -42,7 +51,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
@@ -63,6 +71,9 @@ public class DesignComponentControllerTest {
   private DesignComponentRepository designComponentRepository;
 
   @Autowired
+  private ComponentTypeRepository componentTypeRepository;
+
+  @Autowired
   private MockMvcUtils mockMvcUtils;
 
   @MockitoBean
@@ -76,6 +87,8 @@ public class DesignComponentControllerTest {
 
   private User testUser;
   private TestClientDto testClient;
+  private ComponentType componentTypeA;
+  private ComponentType componentTypeB;
 
 
   @BeforeEach
@@ -83,6 +96,9 @@ public class DesignComponentControllerTest {
     userDataGenerator.deleteAllUsers();
     testUser = userDataGenerator.generateTestUser("test@example.com");
     testClient = TestClientDto.fromEntity(testUser);
+    componentTypeRepository.deleteAll();
+    componentTypeA = createComponentType("comp-a");
+    componentTypeB = createComponentType("comp-b");
 
     when(fileManager.uploadFile(any(byte[].class), anyString()))
         .thenReturn("https://s3.example.com/uploaded-image.png");
@@ -101,7 +117,32 @@ public class DesignComponentControllerTest {
   @AfterEach
   void tearDown() {
     designComponentDataGenerator.deleteDesignComponents();
+    componentTypeRepository.deleteAll();
     userDataGenerator.deleteAllUsers();
+  }
+
+  private ComponentType createComponentType(String suffix) {
+    String fileName = "theme_maintab_cell_image_" + suffix + ".png";
+    return componentTypeRepository.save(ComponentType.builder()
+        .platform(Platform.ANDROID)
+        .componentName(fileName)
+        .componentPath("res/drawable-sw600dp/" + fileName)
+        .sizeX(100)
+        .sizeY(200)
+        .build());
+  }
+
+  private MockMultipartFile createRequestPart(Object request) throws Exception {
+    return mockMvcUtils.jsonToTestFormData("request", request);
+  }
+
+  private MockMultipartFile createImagePart(String fileName) {
+    return mockMvcUtils.fileToTestFormData(
+        "image",
+        fileName,
+        MediaType.IMAGE_PNG,
+        "test-image-content".getBytes()
+    );
   }
 
   @Nested
@@ -112,31 +153,45 @@ public class DesignComponentControllerTest {
     @DisplayName("DesignComponent 생성 테스트")
     void createDesignComponent() throws Exception {
       // Given
-      CreateDesignComponentRequest request = CreateDesignComponentRequest.builder()
+      CreateDesignComponentRequest createRequest = CreateDesignComponentRequest.builder()
           .isPublic(true)
+          .componentTypeIds(
+              List.of(componentTypeA.getComponentTypeId(), componentTypeB.getComponentTypeId()))
           .build();
-
-      MockMultipartFile image = new MockMultipartFile(
-          "image", "test.png", "image/png", "test-image-content".getBytes());
+      MockMultipartFile requestPart = createRequestPart(createRequest);
+      MockMultipartFile image = createImagePart("test.png");
 
       // When & Then
-      MockHttpServletRequestBuilder requestBuilder = multipart("/api/design-components")
-          .file(image)
-          .param("isPublic", "true");
-
-      MvcResult result = mockMvc.perform(mockMvcUtils.addAuthentication(requestBuilder, testClient))
-          .andExpect(status().isOk())
-          .andReturn();
-      DesignComponentDto response = objectMapper.readValue(
-          result.getResponse().getContentAsString(), DesignComponentDto.class);
+      DesignComponentDto response = mockMvcUtils.doAuthMultipartRequest(
+          MockMvcMultipartRequestDto.<DesignComponentDto>builder()
+              .mockMvc(mockMvc)
+              .path("/api/design-components")
+              .httpMethod(HttpMethod.POST)
+              .formDataList(List.of(requestPart, image))
+              .clientDto(testClient)
+              .statusCode(200)
+              .responseType(new TypeReference<>() {
+              })
+              .build()
+      );
 
       assertThat(response.getDesignComponentId()).isNotNull();
       assertThat(response.getPublicUserId()).isEqualTo(testUser.getPublicUserId());
       assertThat(response.getIsPublic()).isTrue();
       assertThat(response.getCreatedAt()).isNotNull();
       assertThat(response.getUpdatedAt()).isNotNull();
+      assertThat(response.getComponentTypes())
+          .extracting("componentTypeId")
+          .containsExactlyInAnyOrder(componentTypeA.getComponentTypeId(),
+              componentTypeB.getComponentTypeId());
 
       assertThat(designComponentRepository.count()).isEqualTo(1);
+      DesignComponent saved = designComponentRepository.findByDesignComponentId(
+          response.getDesignComponentId()).orElseThrow();
+      assertThat(saved.getComponentTypes())
+          .extracting(ComponentType::getComponentTypeId)
+          .containsExactlyInAnyOrder(componentTypeA.getComponentTypeId(),
+              componentTypeB.getComponentTypeId());
     }
 
     @Test
@@ -144,7 +199,7 @@ public class DesignComponentControllerTest {
     void getDesignComponent() throws Exception {
       // Given
       DesignComponent savedComponent = designComponentDataGenerator.generateDesignComponent(
-          testUser, "http://example.com/image.png", false);
+          testUser, "http://example.com/image.png", false, List.of(componentTypeA, componentTypeB));
 
       // When & Then
       MockHttpServletRequestBuilder requestBuilder = get("/api/design-components/{id}",
@@ -162,20 +217,26 @@ public class DesignComponentControllerTest {
       assertThat(response.getImageUrl()).isEqualTo("http://example.com/image.png");
       assertThat(response.getCreatedAt()).isNotNull();
       assertThat(response.getUpdatedAt()).isNotNull();
+      assertThat(response.getComponentTypes())
+          .extracting("componentTypeId")
+          .containsExactlyInAnyOrder(componentTypeA.getComponentTypeId(),
+              componentTypeB.getComponentTypeId());
     }
 
     @Test
     @DisplayName("DesignComponent 전체 조회 테스트")
     void getAllDesignComponents() throws Exception {
       // Given
-      designComponentDataGenerator.generateData(5, 4);
+      designComponentDataGenerator.generateDesignComponents(
+          userDataGenerator.generateTestUsers(5), 4, List.of(componentTypeA));
 
       // When & Then
       MockHttpServletRequestBuilder requestBuilder = get("/api/design-components");
 
       mockMvc.perform(mockMvcUtils.addAuthentication(requestBuilder, testClient))
           .andExpect(status().isOk())
-          .andExpect(jsonPath("$.content.length()").value(20));
+          .andExpect(jsonPath("$.content.length()").value(20))
+          .andExpect(jsonPath("$.content[0].component_types.length()").value(1));
     }
 
     @Test
@@ -186,17 +247,17 @@ public class DesignComponentControllerTest {
 
       // testUser의 design components
       designComponentDataGenerator.generateDesignComponent(testUser,
-          "http://example.com/image1.png", true);
+          "http://example.com/image1.png", true, List.of(componentTypeA));
       designComponentDataGenerator.generateDesignComponent(testUser,
-          "http://example.com/image2.png", true);
+          "http://example.com/image2.png", true, List.of(componentTypeA));
       designComponentDataGenerator.generateDesignComponent(testUser,
-          "http://example.com/image3.png", true);
+          "http://example.com/image3.png", true, List.of(componentTypeB));
 
       // otherUser의 design component
       designComponentDataGenerator.generateDesignComponent(otherUser,
-          "http://example.com/other1.png", true);
+          "http://example.com/other1.png", true, List.of(componentTypeA));
       designComponentDataGenerator.generateDesignComponent(otherUser,
-          "http://example.com/other2.png", true);
+          "http://example.com/other2.png", true, List.of(componentTypeB));
 
       // When & Then - testUser의 desgin components만 조회
       MockHttpServletRequestBuilder requestBuilder = get(
@@ -228,30 +289,27 @@ public class DesignComponentControllerTest {
     void updateDesignComponent() throws Exception {
       // Given
       DesignComponent savedComponent = designComponentDataGenerator.generateDesignComponent(
-          testUser, "http://example.com/image.png", false);
-
+          testUser, "http://example.com/image.png", false, List.of(componentTypeA));
       UpdateDesignComponentRequest updateRequest = UpdateDesignComponentRequest.builder()
           .isPublic(true)
+          .componentTypeIds(List.of(componentTypeB.getComponentTypeId()))
           .build();
-      MockMultipartFile image = new MockMultipartFile(
-          "image", "updated.png", "image/png", "updated-image-content".getBytes());
+      MockMultipartFile requestPart = createRequestPart(updateRequest);
+      MockMultipartFile image = createImagePart("updated.png");
 
       // When & Then
-      MockHttpServletRequestBuilder requestBuilder = multipart(
-          "/api/design-components/{id}", savedComponent.getDesignComponentId())
-          .file(image)
-          .param("isPublic", "true");
-
-      requestBuilder.with(request -> {
-        request.setMethod("PUT");
-        return request;
-      });
-
-      MvcResult result = mockMvc.perform(mockMvcUtils.addAuthentication(requestBuilder, testClient))
-          .andExpect(status().isOk())
-          .andReturn();
-      DesignComponentDto response = objectMapper.readValue(
-          result.getResponse().getContentAsString(), DesignComponentDto.class);
+      DesignComponentDto response = mockMvcUtils.doAuthMultipartRequest(
+          MockMvcMultipartRequestDto.<DesignComponentDto>builder()
+              .mockMvc(mockMvc)
+              .path("/api/design-components/" + savedComponent.getDesignComponentId())
+              .httpMethod(HttpMethod.PUT)
+              .formDataList(List.of(requestPart, image))
+              .clientDto(testClient)
+              .statusCode(200)
+              .responseType(new TypeReference<>() {
+              })
+              .build()
+      );
       assertThat(response.getDesignComponentId()).isEqualTo(savedComponent.getDesignComponentId());
       assertThat(response.getPublicUserId()).isEqualTo(testUser.getPublicUserId());
       assertThat(response.getIsPublic()).isTrue();
@@ -260,6 +318,15 @@ public class DesignComponentControllerTest {
       assertThat(response.getImageUrl()).isEqualTo("https://s3.example.com/uploaded-image.png");
       assertThat(response.getCreatedAt()).isNotNull();
       assertThat(response.getUpdatedAt()).isNotNull();
+      assertThat(response.getComponentTypes())
+          .extracting("componentTypeId")
+          .containsExactly(componentTypeB.getComponentTypeId());
+
+      DesignComponent updated = designComponentRepository.findByDesignComponentId(
+          savedComponent.getDesignComponentId()).orElseThrow();
+      assertThat(updated.getComponentTypes())
+          .extracting(ComponentType::getComponentTypeId)
+          .containsExactly(componentTypeB.getComponentTypeId());
     }
 
     @Test
@@ -268,37 +335,136 @@ public class DesignComponentControllerTest {
       // Given - 다른 사용자가 만든 컴포넌트
       User otherUser = userDataGenerator.generateTestUser("other@test.com");
       DesignComponent savedComponent = designComponentDataGenerator.generateDesignComponent(
-          otherUser, "http://example.com/image.png", false);
-
+          otherUser, "http://example.com/image.png", false, List.of(componentTypeA));
       UpdateDesignComponentRequest updateRequest = UpdateDesignComponentRequest.builder()
           .isPublic(true)
+          .componentTypeIds(List.of(componentTypeB.getComponentTypeId()))
           .build();
-
-      MockMultipartFile image = new MockMultipartFile(
-          "image", "updated.png", "image/png", "updated-image-content".getBytes());
-      MockMultipartFile requestPart = new MockMultipartFile(
-          "request", "", "application/json", objectMapper.writeValueAsBytes(updateRequest));
-
+      MockMultipartFile requestPart = createRequestPart(updateRequest);
+      MockMultipartFile image = createImagePart("updated.png");
       // When & Then - testUser로 수정 시도 (실패해야 함)
-      MockMultipartHttpServletRequestBuilder requestBuilder = multipart(
-          "/api/design-components/{id}", savedComponent.getDesignComponentId())
-          .file(image)
-          .file(requestPart);
-
-      requestBuilder.with(request -> {
-        request.setMethod("PUT");
-        return request;
-      });
+      mockMvcUtils.doAuthMultipartRequest(
+          MockMvcMultipartRequestDto.<Void>builder()
+              .mockMvc(mockMvc)
+              .path("/api/design-components/" + savedComponent.getDesignComponentId())
+              .httpMethod(HttpMethod.PUT)
+              .formDataList(List.of(requestPart, image))
+              .clientDto(testClient)
+              .statusCode(403)
+              .responseType(new TypeReference<>() {
+              })
+              .build()
+      );
 
       // 수정 안됐는지 확인
-      mockMvc.perform(mockMvcUtils.addAuthentication(requestBuilder, testClient))
-          .andExpect(status().isForbidden());
-
       DesignComponent afterComponent = designComponentRepository.findById(
           savedComponent.getDesignComponentId()).get();
       assertThat(afterComponent.getImageUrl()).isEqualTo("http://example.com/image.png");
       assertThat(afterComponent.getIsPublic()).isFalse();
+      assertThat(afterComponent.getComponentTypes())
+          .extracting(ComponentType::getComponentTypeId)
+          .containsExactly(componentTypeA.getComponentTypeId());
 
+    }
+
+    @Test
+    @DisplayName("DesignComponent 생성 시 componentTypeIds 누락 검증")
+    void createDesignComponent_withoutComponentTypeIds() throws Exception {
+      CreateDesignComponentRequest createRequest = CreateDesignComponentRequest.builder()
+          .isPublic(true)
+          .build();
+      MockMultipartFile requestPart = createRequestPart(createRequest);
+      MockMultipartFile image = createImagePart("test.png");
+      mockMvcUtils.doAuthMultipartRequest(
+          MockMvcMultipartRequestDto.<Void>builder()
+              .mockMvc(mockMvc)
+              .path("/api/design-components")
+              .httpMethod(HttpMethod.POST)
+              .formDataList(List.of(requestPart, image))
+              .clientDto(testClient)
+              .statusCode(400)
+              .responseType(new TypeReference<>() {
+              })
+              .build()
+      );
+
+      verify(fileManager, never()).uploadFile(any(byte[].class), anyString());
+    }
+
+    @Test
+    @DisplayName("DesignComponent 생성 시 중복 componentTypeIds 검증")
+    void createDesignComponent_duplicateComponentTypeIds() throws Exception {
+      CreateDesignComponentRequest createRequest = CreateDesignComponentRequest.builder()
+          .isPublic(true)
+          .componentTypeIds(
+              List.of(componentTypeA.getComponentTypeId(), componentTypeA.getComponentTypeId()))
+          .build();
+      MockMultipartFile requestPart = createRequestPart(createRequest);
+      MockMultipartFile image = createImagePart("test.png");
+      mockMvcUtils.doAuthMultipartRequest(
+          MockMvcMultipartRequestDto.<Void>builder()
+              .mockMvc(mockMvc)
+              .path("/api/design-components")
+              .httpMethod(HttpMethod.POST)
+              .formDataList(List.of(requestPart, image))
+              .clientDto(testClient)
+              .statusCode(400)
+              .responseType(new TypeReference<>() {
+              })
+              .build()
+      );
+    }
+
+    @Test
+    @DisplayName("DesignComponent 생성 시 존재하지 않는 componentTypeId 검증")
+    void createDesignComponent_withUnknownComponentTypeId() throws Exception {
+      CreateDesignComponentRequest createRequest = CreateDesignComponentRequest.builder()
+          .isPublic(true)
+          .componentTypeIds(List.of(componentTypeA.getComponentTypeId(), 999999))
+          .build();
+      MockMultipartFile requestPart = createRequestPart(createRequest);
+      MockMultipartFile image = createImagePart("test.png");
+      mockMvcUtils.doAuthMultipartRequest(
+          MockMvcMultipartRequestDto.<Void>builder()
+              .mockMvc(mockMvc)
+              .path("/api/design-components")
+              .httpMethod(HttpMethod.POST)
+              .formDataList(List.of(requestPart, image))
+              .clientDto(testClient)
+              .statusCode(404)
+              .responseType(new TypeReference<>() {
+              })
+              .build()
+      );
+
+      verify(fileManager, never()).uploadFile(any(byte[].class), anyString());
+    }
+
+    @Test
+    @DisplayName("DesignComponent 수정 시 존재하지 않는 componentTypeId 검증")
+    void updateDesignComponent_withUnknownComponentTypeId() throws Exception {
+      DesignComponent savedComponent = designComponentDataGenerator.generateDesignComponent(
+          testUser, "http://example.com/image.png", false, List.of(componentTypeA));
+      UpdateDesignComponentRequest updateRequest = UpdateDesignComponentRequest.builder()
+          .isPublic(true)
+          .componentTypeIds(List.of(999999))
+          .build();
+      MockMultipartFile requestPart = createRequestPart(updateRequest);
+      MockMultipartFile image = createImagePart("updated.png");
+      mockMvcUtils.doAuthMultipartRequest(
+          MockMvcMultipartRequestDto.<Void>builder()
+              .mockMvc(mockMvc)
+              .path("/api/design-components/" + savedComponent.getDesignComponentId())
+              .httpMethod(HttpMethod.PUT)
+              .formDataList(List.of(requestPart, image))
+              .clientDto(testClient)
+              .statusCode(404)
+              .responseType(new TypeReference<>() {
+              })
+              .build()
+      );
+
+      verify(fileManager, never()).uploadFile(any(byte[].class), anyString());
     }
 
 
@@ -327,7 +493,8 @@ public class DesignComponentControllerTest {
       // Given - 다른 사용자가 만든 컴포넌트
       User otherUser = userDataGenerator.generateTestUser("other@test.com");
       DesignComponent savedComponent = designComponentDataGenerator
-          .generateDesignComponent(otherUser, "https://other.com/image.png", false);
+          .generateDesignComponent(otherUser, "https://other.com/image.png", false,
+              List.of(componentTypeA));
 
       // When & Then - testUser로 삭제 시도 (실패해야 함)
       MockHttpServletRequestBuilder requestBuilder =


### PR DESCRIPTION
## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용
- design component, component type 매핑
- 기존에 @ModelAttribute를 사용하여 폼 데이터 필드로 매핑하던 CreateDesignComponentRequest를 @RequestPart("request")로 변경, -> 해당 데이터를 JSON 파트로 전송

관련 이슈: #106  <!-- #issue_number -->


## 테스트 결과
<!-- 테스트 결과를 스크린 샷으로 첨부해주세요. -->
- designComponentControllerTest
<img width="906" height="353" alt="image" src="https://github.com/user-attachments/assets/2d463b6d-d3d2-4dfb-9b4f-50d359e02beb" />
- POST [/api/design-components]
<img width="1394" height="751" alt="image" src="https://github.com/user-attachments/assets/0382772e-e99e-416b-a07a-b14bc865afc3" />
- GET [/api/design-components]
<img width="1385" height="711" alt="image" src="https://github.com/user-attachments/assets/ed9ca532-3efc-454c-b204-cead17acb8a5" />
- PUT [/api/design-components/{id}]
<img width="1400" height="752" alt="image" src="https://github.com/user-attachments/assets/88fbffd6-b52a-456a-9511-02d45754d7b0" />
- DELETE [/api/design-components/{id}]
<img width="1401" height="464" alt="image" src="https://github.com/user-attachments/assets/4b17daa3-4976-4f62-945c-253c5dfdd692" />



## PR 체크리스트
- [ ] 커밋 메시지가 가이드라인을 따르는가
- [ ] 테스트 코드를 모두 통과하였는가
- [ ] 관련 이슈를 연결하였는가
