### PR TITLE
Feat/#144 게시글 시간, 좋아요순 정렬 기능 추가

### DIFF
--- a/src/main/java/com/komentum/post/controller/DesignBoardController.java
+++ b/src/main/java/com/komentum/post/controller/DesignBoardController.java
@@ -7,8 +7,11 @@ import com.komentum.post.dto.DesignBoardDto.DesignBoardDetailDto;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardPreviewDto;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardUpdateDto;
 import com.komentum.post.facade.DesignBoardManagementFacade;
+import com.komentum.post.service.enums.PostSortType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -39,15 +42,29 @@ public class DesignBoardController {
    * 디자인 에셋 게시글 목록 조회
    */
   @GetMapping
-  @Operation(summary = "현재 인증된 사용자가 디자인 에셋 게시글 목록을 조회힌다")
+  @Operation(
+      summary = "현재 인증된 사용자가 디자인 에셋 게시글 목록을 조회힌다",
+      parameters = {
+          @Parameter(name = "page", in = ParameterIn.QUERY, description = "페이지 번호 (0부터 시작)",
+              schema = @Schema(type = "integer", defaultValue = "0", minimum = "0")),
+          @Parameter(name = "size", in = ParameterIn.QUERY, description = "페이지당 게시글 수",
+              schema = @Schema(type = "integer", defaultValue = "20", minimum = "1"))
+      })
   public ResponseEntity<List<DesignBoardPreviewDto>> findDesignBoards(
       @Parameter(description = "게시글 제목/내용 검색어")
       @RequestParam(value = "keyword", required = false) String keyword,
       @Parameter(description = "component type code")
       @RequestParam(value = "type_code", required = false) TypeCode typeCode,
-      @PageableDefault(size = 20, sort = "createdAt") @ParameterObject Pageable pageable) {
+      @Parameter(
+          description = "정렬 기준",
+          schema = @Schema(
+              allowableValues = {"CREATED_ASC", "CREATED_DESC", "PREFER_ASC", "PREFER_DESC"},
+              defaultValue = "CREATED_DESC"))
+      @RequestParam(value = "sort_type", defaultValue = "CREATED_DESC")
+      PostSortType sortType,
+      @Parameter(hidden = true) @PageableDefault(size = 20) Pageable pageable) {
     return ResponseEntity.ok(
-        designBoardManagementFacade.findBoardPreviews(pageable, keyword, typeCode));
+        designBoardManagementFacade.findBoardPreviews(pageable, keyword, typeCode, sortType));
   }
 
   /**

--- a/src/main/java/com/komentum/post/controller/ThemeBoardController.java
+++ b/src/main/java/com/komentum/post/controller/ThemeBoardController.java
@@ -6,8 +6,11 @@ import com.komentum.post.dto.ThemeBoardDto.ThemeBoardDetailDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardPreviewDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardUpdateDto;
 import com.komentum.post.facade.ThemeBoardManagementFacade;
+import com.komentum.post.service.enums.PostSortType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -41,13 +44,27 @@ public class ThemeBoardController {
    * @return 조회한 게시글 목록 반환
    */
   @GetMapping
-  @Operation(summary = "인증된 사용자가 테마 게시글 목록을 조회한다")
+  @Operation(
+      summary = "인증된 사용자가 테마 게시글 목록을 조회한다",
+      parameters = {
+          @Parameter(name = "page", in = ParameterIn.QUERY, description = "페이지 번호 (0부터 시작)",
+              schema = @Schema(type = "integer", defaultValue = "0", minimum = "0")),
+          @Parameter(name = "size", in = ParameterIn.QUERY, description = "페이지당 게시글 수",
+              schema = @Schema(type = "integer", defaultValue = "20", minimum = "1"))
+      })
   public ResponseEntity<List<ThemeBoardPreviewDto>> findThemeBoards(
       @Parameter(description = "게시글 제목/내용 검색어")
       @RequestParam(value = "keyword", required = false) String keyword,
-      @PageableDefault(size = 20, sort = "createdAt") @ParameterObject Pageable pageable) {
+      @Parameter(
+          description = "정렬 기준",
+          schema = @Schema(
+              allowableValues = {"CREATED_ASC", "CREATED_DESC", "PREFER_ASC", "PREFER_DESC"},
+              defaultValue = "CREATED_DESC"))
+      @RequestParam(value = "sort_type", defaultValue = "CREATED_DESC")
+      PostSortType sortType,
+      @Parameter(hidden = true) @PageableDefault(size = 20) Pageable pageable) {
     return ResponseEntity.ok(
-        themeBoardManagementFacade.findThemeBoardPreviews(pageable, keyword));
+        themeBoardManagementFacade.findThemeBoardPreviews(pageable, keyword, sortType));
   }
 
   /**

--- a/src/main/java/com/komentum/post/facade/DesignBoardManagementFacade.java
+++ b/src/main/java/com/komentum/post/facade/DesignBoardManagementFacade.java
@@ -15,6 +15,7 @@ import com.komentum.post.mapper.DesignBoardMapperSupport;
 import com.komentum.post.service.DesignBoardService;
 import com.komentum.post.service.PostService;
 import com.komentum.post.service.TagService;
+import com.komentum.post.service.enums.PostSortType;
 import com.komentum.post.service.transaction.DesignBoardTransactionService;
 import com.komentum.designcomponent.domain.DesignComponent;
 import com.komentum.designcomponent.enums.TypeCode;
@@ -76,14 +77,20 @@ public class DesignBoardManagementFacade {
    * */
   @Transactional(readOnly = true)
   public List<DesignBoardPreviewDto> findBoardPreviews(Pageable pageable) {
-    return findBoardPreviews(pageable, null, null);
+    return findBoardPreviews(pageable, null, null, PostSortType.CREATED_DESC);
   }
 
   @Transactional(readOnly = true)
   public List<DesignBoardPreviewDto> findBoardPreviews(Pageable pageable, String keyword,
       TypeCode typeCode) {
+    return findBoardPreviews(pageable, keyword, typeCode, PostSortType.CREATED_DESC);
+  }
+
+  @Transactional(readOnly = true)
+  public List<DesignBoardPreviewDto> findBoardPreviews(Pageable pageable, String keyword,
+      TypeCode typeCode, PostSortType sortType) {
     List<DesignBoardQuery.Preview> preview = designBoardService.findPreviewList(pageable, keyword,
-        typeCode);
+        typeCode, sortType);
     List<Long> postIds = preview.stream()
         .map(DesignBoardQuery.Preview::getPostId)
         .toList();

--- a/src/main/java/com/komentum/post/facade/ThemeBoardManagementFacade.java
+++ b/src/main/java/com/komentum/post/facade/ThemeBoardManagementFacade.java
@@ -14,6 +14,7 @@ import com.komentum.post.mapper.ThemeBoardMapperSupport;
 import com.komentum.post.service.PostService;
 import com.komentum.post.service.TagService;
 import com.komentum.post.service.ThemeBoardService;
+import com.komentum.post.service.enums.PostSortType;
 import com.komentum.post.service.transaction.ThemeBoardTransactionService;
 import com.komentum.theme.core.domain.ThemeComponent;
 import com.komentum.theme.core.service.ThemeImageService;
@@ -106,13 +107,19 @@ public class ThemeBoardManagementFacade {
    */
   @Transactional(readOnly = true)
   public List<ThemeBoardPreviewDto> findThemeBoardPreviews(Pageable pageable) {
-    return findThemeBoardPreviews(pageable, null);
+    return findThemeBoardPreviews(pageable, null, PostSortType.CREATED_DESC);
   }
 
   @Transactional(readOnly = true)
   public List<ThemeBoardPreviewDto> findThemeBoardPreviews(Pageable pageable, String keyword) {
+    return findThemeBoardPreviews(pageable, keyword, PostSortType.CREATED_DESC);
+  }
+
+  @Transactional(readOnly = true)
+  public List<ThemeBoardPreviewDto> findThemeBoardPreviews(Pageable pageable, String keyword,
+      PostSortType sortType) {
     List<ThemeBoardQuery.Preview> themeBoardQueryPreviewList = themeBoardService.findThemeBoardQueryPreview(
-        pageable, keyword);
+        pageable, keyword, sortType);
     return themeBoardMapperSupport.toThemeBoardPreviewDtoList(themeBoardQueryPreviewList,
         boardManagementHelper);
   }

--- a/src/main/java/com/komentum/post/repository/DesignBoardRepositorySupport.java
+++ b/src/main/java/com/komentum/post/repository/DesignBoardRepositorySupport.java
@@ -104,7 +104,8 @@ public class DesignBoardRepositorySupport {
   }
 
   public List<DesignBoardQuery.Preview> findPreviewList(Pageable pageable) {
-    return findPreviewList(pageable, new PostSearchCondition(), List.of(PostSortType.DEFAULT));
+    return findPreviewList(pageable, new PostSearchCondition(),
+        List.of(PostSortType.CREATED_DESC));
   }
 
   public List<DesignBoardQuery.Preview> findPreviewList(Pageable pageable,
@@ -143,6 +144,7 @@ public class DesignBoardRepositorySupport {
             designBoard.designBoardId
         )
         .orderBy(orderSpecifiers)
+        .orderBy(designBoard.designBoardId.desc())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
         .fetch();

--- a/src/main/java/com/komentum/post/repository/order/PostOrder.java
+++ b/src/main/java/com/komentum/post/repository/order/PostOrder.java
@@ -54,23 +54,29 @@ public class PostOrder {
       NumberExpression<Long> preferCount) {
 
     sortTypeList.forEach(sortType -> {
-      OrderSpecifier<?> orderSpecifier = switch (sortType) {
-        case DEFAULT -> post.createdAt.desc();
+      switch (sortType) {
+        case CREATED_ASC -> orderSpecifiers.add(post.createdAt.asc());
+        case CREATED_DESC -> orderSpecifiers.add(post.createdAt.desc());
         case PREFER_ASC -> {
           if (preferCount == null) {
             throw new IllegalArgumentException("preferCount is null");
           }
-          yield preferCount.asc();
+          orderSpecifiers.add(preferCount.asc());
         }
         case PREFER_DESC -> {
           if (preferCount == null) {
             throw new IllegalArgumentException("preferCount is null");
           }
-          yield preferCount.desc();
+          orderSpecifiers.add(preferCount.desc());
         }
-      };
-      orderSpecifiers.add(orderSpecifier);
+      }
     });
+    if (sortTypeList.stream()
+        .noneMatch(sortType -> sortType == PostSortType.CREATED_ASC
+            || sortType == PostSortType.CREATED_DESC)) {
+      orderSpecifiers.add(post.createdAt.desc());
+    }
+    orderSpecifiers.add(post.postId.desc());
   }
 
   public static OrderSpecifier<?>[] create(

--- a/src/main/java/com/komentum/post/service/DesignBoardService.java
+++ b/src/main/java/com/komentum/post/service/DesignBoardService.java
@@ -39,17 +39,23 @@ public class DesignBoardService {
 
   @Transactional(readOnly = true)
   public List<DesignBoardQuery.Preview> findPreviewList(Pageable pageable) {
-    return findPreviewList(pageable, null, null);
+    return findPreviewList(pageable, null, null, PostSortType.CREATED_DESC);
   }
 
   @Transactional(readOnly = true)
   public List<DesignBoardQuery.Preview> findPreviewList(Pageable pageable, String keyword,
       TypeCode typeCode) {
+    return findPreviewList(pageable, keyword, typeCode, PostSortType.CREATED_DESC);
+  }
+
+  @Transactional(readOnly = true)
+  public List<DesignBoardQuery.Preview> findPreviewList(Pageable pageable, String keyword,
+      TypeCode typeCode, PostSortType sortType) {
     PostSearchCondition condition = new PostSearchCondition()
         .withKeyword(keyword)
         .withTypeCode(typeCode);
     return designBoardRepositorySupport.findPreviewList(pageable, condition,
-        List.of(PostSortType.DEFAULT));
+        List.of(sortType));
   }
 
   @Transactional(readOnly = true)
@@ -91,7 +97,7 @@ public class DesignBoardService {
             pageable,
             client,
             condition,
-            List.of(PostSortType.DEFAULT)
+            List.of(PostSortType.CREATED_DESC)
         )
     );
   }

--- a/src/main/java/com/komentum/post/service/ThemeBoardService.java
+++ b/src/main/java/com/komentum/post/service/ThemeBoardService.java
@@ -34,15 +34,20 @@ public class ThemeBoardService {
    * @return ThemeBoardQuery.Preview 테마 게시글 페이징 DTO 생성을 위한 중간 계층 DTO 반환
    * */
   public List<ThemeBoardQuery.Preview> findThemeBoardQueryPreview(Pageable pageable) {
-    return findThemeBoardQueryPreview(pageable, null);
+    return findThemeBoardQueryPreview(pageable, null, PostSortType.CREATED_DESC);
   }
 
   public List<ThemeBoardQuery.Preview> findThemeBoardQueryPreview(Pageable pageable,
       String keyword) {
+    return findThemeBoardQueryPreview(pageable, keyword, PostSortType.CREATED_DESC);
+  }
+
+  public List<ThemeBoardQuery.Preview> findThemeBoardQueryPreview(Pageable pageable,
+      String keyword, PostSortType sortType) {
     PostSearchCondition condition = new PostSearchCondition()
         .withKeyword(keyword);
     return themeBoardRepositorySupport.findThemeBoardQueryPreviewList(pageable, condition,
-        List.of(PostSortType.DEFAULT));
+        List.of(sortType));
   }
 
   /**
@@ -79,7 +84,7 @@ public class ThemeBoardService {
             pageable,
             client,
             condition,
-            List.of(PostSortType.DEFAULT)
+            List.of(PostSortType.CREATED_DESC)
         )
     );
   }

--- a/src/main/java/com/komentum/post/service/enums/PostSortType.java
+++ b/src/main/java/com/komentum/post/service/enums/PostSortType.java
@@ -5,7 +5,8 @@ package com.komentum.post.service.enums;
  * Post, DesignBoard, ThemeBoard 정렬 기준 설정 시 사용 가능
  * */
 public enum PostSortType {
-  DEFAULT,
+  CREATED_ASC,
+  CREATED_DESC,
   PREFER_ASC,
   PREFER_DESC
 }

--- a/src/test/java/com/komentum/post/controller/DesignBoardControllerTest.java
+++ b/src/test/java/com/komentum/post/controller/DesignBoardControllerTest.java
@@ -14,6 +14,7 @@ import com.komentum.designcomponent.service.seeder.ComponentTypeSeeder;
 import com.komentum.global.utils.FileManager;
 import com.komentum.post.domain.DesignBoard;
 import com.komentum.post.domain.Post;
+import com.komentum.post.domain.Prefer;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardCreateDto;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardDetailDto;
 import com.komentum.post.dto.DesignBoardDto.DesignBoardPreviewDto;
@@ -23,6 +24,7 @@ import com.komentum.post.dto.TagDto.TagResponse;
 import com.komentum.post.dto.TagDto.TagUpdateDto;
 import com.komentum.post.repository.DesignBoardRepository;
 import com.komentum.post.repository.PostRepository;
+import com.komentum.post.repository.PreferRepository;
 import com.komentum.test.MockMvcUtils;
 import com.komentum.test.config.EnableTestProfile;
 import com.komentum.test.data.MockMultipartFileUtils;
@@ -36,6 +38,9 @@ import com.komentum.test.dto.MockMvcRequestDto;
 import com.komentum.test.dto.TestClientDto;
 import com.komentum.test.dto.TestParams;
 import com.komentum.user.domain.User;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -44,6 +49,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -63,6 +71,9 @@ public class DesignBoardControllerTest {
 
   @Autowired
   private PostRepository postRepository;
+
+  @Autowired
+  private PreferRepository preferRepository;
 
   @Autowired
   private DesignBoardRepository designBoardRepository;
@@ -169,6 +180,55 @@ public class DesignBoardControllerTest {
     );
   }
 
+  private List<DesignBoardPreviewDto> requestDesignBoardPreviews(
+      MultiValueMap<String, String> params, User client) throws Exception {
+    return mockMvcUtils.doAuthRequest(
+        MockMvcRequestDto.<Void, List<DesignBoardPreviewDto>>builder()
+            .mockMvc(mockMvc)
+            .httpMethod(HttpMethod.GET)
+            .path("/api/design-boards")
+            .params(params)
+            .responseType(new TypeReference<>() {
+            })
+            .clientDto(TestClientDto.fromEntity(client))
+            .build()
+    );
+  }
+
+  private void prepareDesignBoardSortData() {
+    LocalDateTime baseDate = LocalDateTime.of(2025, 1, 1, 0, 0);
+    List<Prefer> prefers = new ArrayList<>();
+    for (int i = 0; i < postResult.posts().size(); i++) {
+      Post post = postResult.posts().get(i);
+      post.setCreatedAt(baseDate.plusDays(i));
+      for (int j = 0; j < i % 3; j++) {
+        prefers.add(Prefer.createTransient(post, userResult.users().get(j)));
+      }
+    }
+    postRepository.saveAll(postResult.posts());
+    preferRepository.saveAll(prefers);
+  }
+
+  private Comparator<DesignBoardPreviewDto> designBoardComparator(String sortType) {
+    Comparator<DesignBoardPreviewDto> createdAtDesc = Comparator.comparing(
+        DesignBoardPreviewDto::getCreatedAt, Comparator.reverseOrder());
+    Comparator<DesignBoardPreviewDto> postIdDesc = Comparator.comparing(
+        DesignBoardPreviewDto::getPostId, Comparator.reverseOrder());
+    return switch (sortType == null ? "CREATED_DESC" : sortType) {
+      case "CREATED_ASC" -> Comparator.comparing(DesignBoardPreviewDto::getCreatedAt)
+          .thenComparing(postIdDesc);
+      case "CREATED_DESC" -> createdAtDesc.thenComparing(postIdDesc);
+      case "PREFER_ASC" -> Comparator.comparing(DesignBoardPreviewDto::getPrefers)
+          .thenComparing(createdAtDesc)
+          .thenComparing(postIdDesc);
+      case "PREFER_DESC" -> Comparator.comparing(
+              DesignBoardPreviewDto::getPrefers, Comparator.reverseOrder())
+          .thenComparing(createdAtDesc)
+          .thenComparing(postIdDesc);
+      default -> throw new IllegalArgumentException("unsupported sort type: " + sortType);
+    };
+  }
+
   private ComponentType getComponentType(TypeCode typeCode) {
     componentTypeSeeder.upsertComponentType();
     return componentTypeRepository.findAllByTypeCodeIn(List.of(typeCode)).get(0);
@@ -196,6 +256,33 @@ public class DesignBoardControllerTest {
     );
     // then
     assertThat(responses).isNotNull().hasSize(pageSize);
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"CREATED_ASC", "CREATED_DESC", "PREFER_ASC", "PREFER_DESC"})
+  @DisplayName("디자인 게시글 목록을 생성일 또는 좋아요 수 기준으로 정렬한다.")
+  void findDesignBoards_sortType(String sortType) throws Exception {
+    // given
+    prepareDesignBoardSortData();
+    User client = userResult.getFirstUser();
+    MultiValueMap<String, String> params = TestParams.withPaging(0,
+        postResult.designBoards().size());
+    if (sortType != null) {
+      params.add("sort_type", sortType);
+    }
+    // when
+    List<DesignBoardPreviewDto> response = requestDesignBoardPreviews(params, client);
+    // then
+    assertThat(response)
+        .hasSize(postResult.designBoards().size())
+        .isSortedAccordingTo(designBoardComparator(sortType));
+
+    MultiValueMap<String, String> repeatedParams = TestParams.withPaging(0,
+        postResult.designBoards().size());
+    repeatedParams.add("sort_type", sortType == null ? "CREATED_DESC" : sortType);
+    assertThat(requestDesignBoardPreviews(repeatedParams, client))
+        .containsExactlyElementsOf(response);
   }
 
   @Test

--- a/src/test/java/com/komentum/post/controller/ThemeBoardControllerTest.java
+++ b/src/test/java/com/komentum/post/controller/ThemeBoardControllerTest.java
@@ -33,10 +33,15 @@ import com.komentum.user.domain.User;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -66,12 +71,20 @@ class ThemeBoardControllerTest {
   @Autowired
   private FileManager fileManager;
 
-  private final int maxPreferPerPost = 5;
+  private final int maxPreferPerPost = 3;
 
   @BeforeEach
   void setUp() {
     boardDetailDataGenerator.deleteThemeBoards();
     boardDetailDataGenerator.generateThemeBoards(5, 2, 2, maxPreferPerPost);
+    LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
+    List<Post> posts = boardDetailDataGenerator.getThemeBoards().stream()
+        .map(ThemeBoard::getPost)
+        .toList();
+    for (int i = 0; i < posts.size(); i++) {
+      posts.get(i).setCreatedAt(baseTime.plusDays(Math.min(i, 3)));
+    }
+    postRepository.saveAll(posts);
   }
 
   @AfterEach
@@ -122,6 +135,121 @@ class ThemeBoardControllerTest {
             })
             .build()
     );
+  }
+
+  private List<ThemeBoardPreviewDto> requestThemeBoardPreviews(
+      MultiValueMap<String, String> params, User client) throws Exception {
+    return mockMvcUtils.doAuthRequest(
+        MockMvcRequestDto.<Void, List<ThemeBoardPreviewDto>>builder()
+            .mockMvc(mockMvc)
+            .path("/api/theme-boards")
+            .params(params)
+            .httpMethod(HttpMethod.GET)
+            .clientDto(TestClientDto.fromEntity(client))
+            .statusCode(200)
+            .responseType(new TypeReference<>() {
+            })
+            .build()
+    );
+  }
+
+  static Stream<Arguments> themeBoardSortCases() {
+    return Stream.of(
+        Arguments.of("CREATED_ASC", List.of(0, 1, 2, 4, 3)),
+        Arguments.of("CREATED_DESC", List.of(4, 3, 2, 1, 0)),
+        Arguments.of("PREFER_ASC", List.of(4, 3, 2, 1, 0)),
+        Arguments.of("PREFER_DESC", List.of(0, 1, 2, 4, 3))
+    );
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("themeBoardSortCases")
+  @DisplayName("테마 게시글 목록을 생성 시간 또는 좋아요 수로 정렬한다.")
+  void findThemeBoards_sort(String sortType, List<Integer> expectedIndexes) throws Exception {
+    // given
+    User client = boardDetailDataGenerator.getUsers().get(0);
+    Mockito.when(fileManager.resolveFilePath(anyString()))
+        .thenReturn(UUID.randomUUID().toString());
+    MultiValueMap<String, String> params = TestParams.withPaging(0, 5);
+    params.add("sort_type", sortType);
+    List<Long> expectedPostIds = expectedIndexes.stream()
+        .map(index -> boardDetailDataGenerator.getThemeBoards().get(index).getPost().getPostId())
+        .toList();
+    // when
+    List<ThemeBoardPreviewDto> response = requestThemeBoardPreviews(params, client);
+    // then
+    assertThat(response)
+        .extracting(ThemeBoardPreviewDto::getPostId)
+        .containsExactlyElementsOf(expectedPostIds);
+  }
+
+  @Test
+  @DisplayName("테마 게시글 정렬값을 생략하면 생성 시간 내림차순으로 정렬한다.")
+  void findThemeBoards_defaultSort() throws Exception {
+    // given
+    User client = boardDetailDataGenerator.getUsers().get(0);
+    Mockito.when(fileManager.resolveFilePath(anyString()))
+        .thenReturn(UUID.randomUUID().toString());
+    MultiValueMap<String, String> defaultParams = TestParams.withPaging(0, 5);
+    MultiValueMap<String, String> blankParams = TestParams.withPaging(0, 5);
+    blankParams.add("sort_type", "");
+    MultiValueMap<String, String> createdDescParams = TestParams.withPaging(0, 5);
+    createdDescParams.add("sort_type", "CREATED_DESC");
+    // when
+    List<ThemeBoardPreviewDto> defaultResponse = requestThemeBoardPreviews(defaultParams, client);
+    List<ThemeBoardPreviewDto> blankResponse = requestThemeBoardPreviews(blankParams, client);
+    List<ThemeBoardPreviewDto> createdDescResponse = requestThemeBoardPreviews(createdDescParams,
+        client);
+    // then
+    List<Long> expectedPostIds = createdDescResponse.stream()
+        .map(ThemeBoardPreviewDto::getPostId)
+        .toList();
+    assertThat(defaultResponse)
+        .extracting(ThemeBoardPreviewDto::getPostId)
+        .containsExactlyElementsOf(expectedPostIds);
+    assertThat(blankResponse)
+        .extracting(ThemeBoardPreviewDto::getPostId)
+        .containsExactlyElementsOf(expectedPostIds);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"DEFAULT", "created_desc"})
+  @DisplayName("지원하지 않는 테마 게시글 정렬값은 400을 반환한다.")
+  void findThemeBoards_invalidSort(String sortType) throws Exception {
+    // given
+    User client = boardDetailDataGenerator.getUsers().get(0);
+    MultiValueMap<String, String> params = TestParams.withPaging(0, 5);
+    params.add("sort_type", sortType);
+    // when & then
+    mockMvc.perform(mockMvcUtils.addAuthentication(
+            get("/api/theme-boards").params(params), TestClientDto.fromEntity(client)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").isNotEmpty());
+  }
+
+  @Test
+  @DisplayName("게시글 목록 API 문서에는 sort_type만 정렬 조건으로 노출한다.")
+  void postBoardListOpenApi_excludesPageableSort() throws Exception {
+    User client = boardDetailDataGenerator.getUsers().get(0);
+    mockMvc.perform(mockMvcUtils.addAuthentication(
+            get("/v3/api-docs"), TestClientDto.fromEntity(client)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath(
+            "$.paths['/api/theme-boards'].get.parameters[?(@.name == 'page')]").isNotEmpty())
+        .andExpect(jsonPath(
+            "$.paths['/api/theme-boards'].get.parameters[?(@.name == 'size')]").isNotEmpty())
+        .andExpect(jsonPath(
+            "$.paths['/api/theme-boards'].get.parameters[?(@.name == 'sort_type')]").isNotEmpty())
+        .andExpect(jsonPath(
+            "$.paths['/api/theme-boards'].get.parameters[?(@.name == 'sort')]").isEmpty())
+        .andExpect(jsonPath(
+            "$.paths['/api/design-boards'].get.parameters[?(@.name == 'page')]").isNotEmpty())
+        .andExpect(jsonPath(
+            "$.paths['/api/design-boards'].get.parameters[?(@.name == 'size')]").isNotEmpty())
+        .andExpect(jsonPath(
+            "$.paths['/api/design-boards'].get.parameters[?(@.name == 'sort_type')]").isNotEmpty())
+        .andExpect(jsonPath(
+            "$.paths['/api/design-boards'].get.parameters[?(@.name == 'sort')]").isEmpty());
   }
 
   @Test
@@ -274,42 +402,34 @@ class ThemeBoardControllerTest {
   void findThemeBoards_keywordMatchedPostFirst() throws Exception {
     // given
     User client = boardDetailDataGenerator.getUsers().get(0);
-    ThemeBoard targetThemeBoard = boardDetailDataGenerator.getThemeBoards().get(0);
+    ThemeBoard targetThemeBoard = boardDetailDataGenerator.getThemeBoards().get(3);
     ThemeBoard contentMatchedThemeBoard = boardDetailDataGenerator.getThemeBoards().get(
         boardDetailDataGenerator.getThemeBoards().size() - 1);
     Post targetPost = targetThemeBoard.getPost();
     Post contentMatchedPost = contentMatchedThemeBoard.getPost();
     String keyword = "theme-keyword-" + UUID.randomUUID();
     targetPost.setTitle(keyword);
-    targetPost.setCreatedAt(LocalDateTime.now().minusDays(1));
     contentMatchedPost.setTitle("content-match-only-" + UUID.randomUUID());
     contentMatchedPost.setContent(keyword);
-    contentMatchedPost.setCreatedAt(LocalDateTime.now());
     postRepository.saveAll(List.of(targetPost, contentMatchedPost));
     Mockito.when(fileManager.resolveFilePath(anyString()))
         .thenReturn(UUID.randomUUID().toString());
-    MultiValueMap<String, String> params = TestParams.withPaging(0,
-        boardDetailDataGenerator.getThemeBoards().size());
-    params.add("keyword", keyword);
+    MultiValueMap<String, String> firstPageParams = TestParams.withPaging(0, 1);
+    firstPageParams.add("keyword", keyword);
+    firstPageParams.add("sort_type", "PREFER_ASC");
+    MultiValueMap<String, String> secondPageParams = TestParams.withPaging(1, 1);
+    secondPageParams.add("keyword", keyword);
+    secondPageParams.add("sort_type", "PREFER_ASC");
     // when
-    List<ThemeBoardPreviewDto> response = mockMvcUtils.doAuthRequest(
-        MockMvcRequestDto.<Void, List<ThemeBoardPreviewDto>>builder()
-            .mockMvc(mockMvc)
-            .path("/api/theme-boards")
-            .params(params)
-            .httpMethod(HttpMethod.GET)
-            .clientDto(TestClientDto.fromEntity(client))
-            .statusCode(200)
-            .responseType(new TypeReference<>() {
-            })
-            .build()
-    );
+    List<ThemeBoardPreviewDto> firstPage = requestThemeBoardPreviews(firstPageParams, client);
+    List<ThemeBoardPreviewDto> secondPage = requestThemeBoardPreviews(secondPageParams, client);
     // then
-    assertThat(response).hasSize(boardDetailDataGenerator.getThemeBoards().size());
-    assertThat(response.get(0).getPostId()).isEqualTo(targetPost.getPostId());
-    assertThat(response)
+    assertThat(firstPage)
         .extracting(ThemeBoardPreviewDto::getPostId)
-        .contains(contentMatchedPost.getPostId());
+        .containsExactly(targetPost.getPostId());
+    assertThat(secondPage)
+        .extracting(ThemeBoardPreviewDto::getPostId)
+        .containsExactly(contentMatchedPost.getPostId());
   }
 
   @Test

--- a/src/test/java/com/komentum/post/controller/ThemeBoardControllerTest.java
+++ b/src/test/java/com/komentum/post/controller/ThemeBoardControllerTest.java
@@ -228,31 +228,6 @@ class ThemeBoardControllerTest {
   }
 
   @Test
-  @DisplayName("게시글 목록 API 문서에는 sort_type만 정렬 조건으로 노출한다.")
-  void postBoardListOpenApi_excludesPageableSort() throws Exception {
-    User client = boardDetailDataGenerator.getUsers().get(0);
-    mockMvc.perform(mockMvcUtils.addAuthentication(
-            get("/v3/api-docs"), TestClientDto.fromEntity(client)))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath(
-            "$.paths['/api/theme-boards'].get.parameters[?(@.name == 'page')]").isNotEmpty())
-        .andExpect(jsonPath(
-            "$.paths['/api/theme-boards'].get.parameters[?(@.name == 'size')]").isNotEmpty())
-        .andExpect(jsonPath(
-            "$.paths['/api/theme-boards'].get.parameters[?(@.name == 'sort_type')]").isNotEmpty())
-        .andExpect(jsonPath(
-            "$.paths['/api/theme-boards'].get.parameters[?(@.name == 'sort')]").isEmpty())
-        .andExpect(jsonPath(
-            "$.paths['/api/design-boards'].get.parameters[?(@.name == 'page')]").isNotEmpty())
-        .andExpect(jsonPath(
-            "$.paths['/api/design-boards'].get.parameters[?(@.name == 'size')]").isNotEmpty())
-        .andExpect(jsonPath(
-            "$.paths['/api/design-boards'].get.parameters[?(@.name == 'sort_type')]").isNotEmpty())
-        .andExpect(jsonPath(
-            "$.paths['/api/design-boards'].get.parameters[?(@.name == 'sort')]").isEmpty());
-  }
-
-  @Test
   @DisplayName("페이지 기반 테마 게시글 목록 조회 성공 테스트")
   void getPosts_success() throws Exception {
     // given

--- a/src/test/java/com/komentum/post/controller/ThemeBoardControllerTest.java
+++ b/src/test/java/com/komentum/post/controller/ThemeBoardControllerTest.java
@@ -20,6 +20,7 @@ import com.komentum.post.dto.ThemeBoardDto.ThemeBoardDetailDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardPreviewDto;
 import com.komentum.post.dto.ThemeBoardDto.ThemeBoardUpdateDto;
 import com.komentum.post.repository.PostRepository;
+import com.komentum.post.repository.PreferRepository;
 import com.komentum.test.MockMvcUtils;
 import com.komentum.test.config.EnableTestProfile;
 import com.komentum.test.data.MockMultipartFileUtils;
@@ -67,6 +68,9 @@ class ThemeBoardControllerTest {
 
   @Autowired
   private PostRepository postRepository;
+
+  @Autowired
+  private PreferRepository preferRepository;
 
   @Autowired
   private MockMvc mockMvc;
@@ -197,10 +201,10 @@ class ThemeBoardControllerTest {
 
   static Stream<Arguments> themeBoardSortCases() {
     return Stream.of(
-        Arguments.of("CREATED_ASC", List.of(0, 1, 2, 4, 3)),
-        Arguments.of("CREATED_DESC", List.of(4, 3, 2, 1, 0)),
-        Arguments.of("PREFER_ASC", List.of(4, 3, 2, 1, 0)),
-        Arguments.of("PREFER_DESC", List.of(0, 1, 2, 4, 3))
+        Arguments.of("CREATED_ASC", List.of(0, 1, 2, 3, 4, 5, 6, 7)),
+        Arguments.of("CREATED_DESC", List.of(7, 6, 5, 4, 3, 2, 1, 0)),
+        Arguments.of("PREFER_ASC", List.of(0, 7, 6, 5, 4, 3, 2, 1)),
+        Arguments.of("PREFER_DESC", List.of(7, 6, 5, 4, 3, 2, 1, 0))
     );
   }
 
@@ -209,13 +213,21 @@ class ThemeBoardControllerTest {
   @DisplayName("테마 게시글 목록을 생성 시간 또는 좋아요 수로 정렬한다.")
   void findThemeBoards_sort(String sortType, List<Integer> expectedIndexes) throws Exception {
     // given
-    User client = boardDetailDataGenerator.getUsers().get(0);
+    User client = testClient;
+    List<Post> posts = postScenarioResult.posts();
+    preferRepository.deleteAll(preferRepository.fetchJoinByPostIn(List.of(posts.get(0))));
+    LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
+    for (int i = 0; i < posts.size(); i++) {
+      posts.get(i).setCreatedAt(baseTime.plusDays(i));
+    }
+    postRepository.saveAll(posts);
     Mockito.when(fileManager.resolveFilePath(anyString()))
         .thenReturn(UUID.randomUUID().toString());
-    MultiValueMap<String, String> params = TestParams.withPaging(0, 5);
+    MultiValueMap<String, String> params = TestParams.withPaging(0,
+        postScenarioResult.themeBoards().size());
     params.add("sort_type", sortType);
     List<Long> expectedPostIds = expectedIndexes.stream()
-        .map(index -> boardDetailDataGenerator.getThemeBoards().get(index).getPost().getPostId())
+        .map(index -> postScenarioResult.themeBoards().get(index).getPost().getPostId())
         .toList();
     // when
     List<ThemeBoardPreviewDto> response = requestThemeBoardPreviews(params, client);
@@ -229,7 +241,7 @@ class ThemeBoardControllerTest {
   @DisplayName("테마 게시글 정렬값을 생략하면 생성 시간 내림차순으로 정렬한다.")
   void findThemeBoards_defaultSort() throws Exception {
     // given
-    User client = boardDetailDataGenerator.getUsers().get(0);
+    User client = testClient;
     Mockito.when(fileManager.resolveFilePath(anyString()))
         .thenReturn(UUID.randomUUID().toString());
     MultiValueMap<String, String> defaultParams = TestParams.withPaging(0, 5);
@@ -259,7 +271,7 @@ class ThemeBoardControllerTest {
   @DisplayName("지원하지 않는 테마 게시글 정렬값은 400을 반환한다.")
   void findThemeBoards_invalidSort(String sortType) throws Exception {
     // given
-    User client = boardDetailDataGenerator.getUsers().get(0);
+    User client = testClient;
     MultiValueMap<String, String> params = TestParams.withPaging(0, 5);
     params.add("sort_type", sortType);
     // when & then
@@ -538,8 +550,8 @@ class ThemeBoardControllerTest {
     secondPageParams.add("keyword", keyword);
     secondPageParams.add("sort_type", "PREFER_ASC");
     // when
-    List<ThemeBoardPreviewDto> firstPage = requestThemeBoardPreviews(firstPageParams, client);
-    List<ThemeBoardPreviewDto> secondPage = requestThemeBoardPreviews(secondPageParams, client);
+    List<ThemeBoardPreviewDto> firstPage = requestThemeBoardPreviews(firstPageParams, testClient);
+    List<ThemeBoardPreviewDto> secondPage = requestThemeBoardPreviews(secondPageParams, testClient);
     // then
     assertThat(firstPage)
         .extracting(ThemeBoardPreviewDto::getPostId)


### PR DESCRIPTION
## PR 타입
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용

- 테마·디자인 게시글 목록 API에 sort_type 정렬 조건을 추가
  - CREATED_ASC
  - CREATED_DESC (기본값)
  - PREFER_ASC
  - PREFER_DESC
- 좋아요 수가 같은 경우 생성일 및 게시글 ID를 기준으로 안정적으로 정렬하도록 개선
- 디자인 게시글의 중복 행도 designBoardId를 기준으로 순서를 고정

관련 이슈: #144  <!-- #issue_number -->


## 테스트 결과
<!-- 테스트 결과를 스크린 샷으로 첨부해주세요. -->
<img width="727" height="448" alt="image" src="https://github.com/user-attachments/assets/a75afe06-1366-4ed9-99f0-3b7ea05bb3e4" />
<img width="1435" height="548" alt="image" src="https://github.com/user-attachments/assets/5125edf9-59cb-4121-a91c-5c9a8abb8607" />
<img width="1407" height="692" alt="image" src="https://github.com/user-attachments/assets/008e3fd6-6bf8-491e-859a-6ba7a50607ea" />



## PR 체크리스트
- [x] 커밋 메시지가 가이드라인을 따르는가
- [ ] 테스트 코드를 모두 통과하였는가
- [x] 관련 이슈를 연결하였는가
