### PR TITLE
Feat/#154 테마 제작 기능, 수정 기능 개선 ( 색상 투명도, Platform 정보 포함 )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ docker/docker_redis/
 
 keystore
 **/keystore/**
+
+# claude & code-review-graph
+.claude/
+.code-review-graph/
+.mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+<!-- project 공통 규칙 / 컨벤션 -->
+
+## 프로젝트 공통 규칙 및 컨벤션
+
+### 네이밍 컨벤션
+
+- path variable : camel case
+- query string : camel case
+- request body : camel case
+- response body : camel case
+
+### 코딩 컨벤션
+
+- 새로 개발한 메서드에 대해서는 JavaDocs 주석 작성하기
+
+```
+/**
+메서드 역할 ( 책임 ) 필수
+- @param 파라미터 종류 ( 간단한거 같으면 생략 )
+- @return 리턴값 ( 간단한거 같으면 생략 )
+- @throw 예외값
+*/
+```
+
+- NullPointException이나 비즈니스 규칙 상 범위를 벗어날 수 있는 값들에 대해서는 예외처리하기
+
+### 아키텍처 규칙
+
+- DB 접근은 반드시 Repository 레이어를 통해 진행
+- 비즈니스 로직은 service 레이어에서 처리
+- 단일 도메인 관련 비즈니스 로직은 service에서, 복합 서비스 로직은 facade에서 처리
+
+### [CRITICAL]
+
+- 프로젝트의 기존 구조와 구현 방식을 최대한 유지하면서 요구사항을 구현하기
+- 불필요한 추상화나 미래의 요구사항을 위한 구조 변경은 하지 않기
+- 구현 후 관련 테스트를 실행하고, 필요한 테스트가 없다면 적절한 테스트 추가하기
+- 너무 과한 경우에 대한 테스트는 작성하지 않기
+- 구현과 테스트가 완료된 후 Knowledge Graph(KG)를 갱신하기
+  - python venv 위치: {projectRoot}/../venv
+  - 실행 명령어: code-review-graph build
+  - KG 갱신은 최종 코드 변경과 테스트가 완료된 이후 마지막 단계에서 수행하기
+
+### 테스트 규칙
+
+- 통합 테스트 코드는 반드시 작성
+- 단위 테스트의 경우 변경의 핵심 로직 / 문제 발생 가능성이 높은 로직의 경우 작성
+- 테스트 작성 시 테스트의 역할을 @DisplayName을 통해 명시
+
+<!-- code-review-graph MCP tools -->
+
+## MCP Tools: code-review-graph
+
+**This project has a knowledge graph. Start with the code-review-graph
+MCP tools to narrow scope, then read the source.** The graph is cheaper than scanning files and
+gives you structural context (callers, dependents, test coverage) that file search cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes_tool` or `query_graph_tool` instead of Grep
+- **Understanding impact**: `get_impact_radius_tool` instead of manually tracing imports
+- **Code review**: `detect_changes_tool` + `get_review_context_tool` instead of reading entire files
+- **Finding relationships**: `query_graph_tool` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview_tool` + `list_communities_tool`
+
+### Verify in the source
+
+- Narrow scope with the graph, then read the source. Do not change code from graph output alone.
+- For any non-trivial change, read the implementation and the relevant tests before concluding.
+- Verify the exact source when touching behavior, database logic, migrations, retries, fallbacks,
+  recovery, or compatibility code.
+- When the graph and the source disagree, the source wins. The graph may be stale or may not
+  model that relationship.
+- An empty graph result can mean "not indexed" or "not statically visible", not "does not exist".
+
+### Key Tools
+
+| Tool                             | Use when                                               |
+| -------------------------------- | ------------------------------------------------------ |
+| `detect_changes_tool`            | Reviewing code changes — gives risk-scored analysis    |
+| `get_review_context_tool`        | Need source snippets for review — token-efficient      |
+| `get_impact_radius_tool`         | Understanding blast radius of a change                 |
+| `get_affected_flows_tool`        | Finding which execution paths are impacted             |
+| `query_graph_tool`               | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes_tool`     | Finding functions/classes by name or keyword           |
+| `get_architecture_overview_tool` | Understanding high-level codebase structure            |
+| `refactor_tool`                  | Planning renames, finding dead code                    |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes_tool` for code review.
+3. Use `get_affected_flows_tool` to understand impact.
+4. Use `query_graph_tool` pattern="tests_for" to check coverage.
+<!-- /code-review-graph MCP tools -->

--- a/src/main/java/com/komentum/designcomponent/domain/ColorStyle.java
+++ b/src/main/java/com/komentum/designcomponent/domain/ColorStyle.java
@@ -1,6 +1,7 @@
 package com.komentum.designcomponent.domain;
 
 import com.komentum.designcomponent.dto.ColorStyleUpdateRequest;
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.StyleCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -39,6 +40,14 @@ public class ColorStyle {
   @Column(nullable = false)
   private StyleCode styleCode;
 
+  /**
+   * 이 color style이 공통으로 사용되는지, 특정 플랫폼 전용인지를 나타낸다.
+   */
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  @Column(name = "platform_scope", nullable = false)
+  private PlatformScope platformScope = PlatformScope.COMMON;
+
   public void update(ColorStyleUpdateRequest colorStyle) {
     if (colorStyle.getExplain() != null) {
       this.explain = colorStyle.getExplain();
@@ -49,12 +58,16 @@ public class ColorStyle {
     if (colorStyle.getStyleCode() != null) {
       this.styleCode = colorStyle.getStyleCode();
     }
+    if (colorStyle.getPlatformScope() != null) {
+      this.platformScope = colorStyle.getPlatformScope();
+    }
   }
 
   public void replace(ColorStyle source) {
     this.explain = source.getExplain();
     this.styleCode = source.getStyleCode();
     this.name = source.getName();
+    this.platformScope = source.getPlatformScope();
   }
 
   public boolean isSame(ColorStyle other) {
@@ -63,6 +76,7 @@ public class ColorStyle {
     }
     return Objects.equals(this.explain, other.explain)
         && this.styleCode.equals(other.styleCode)
-        && this.name.equals(other.name);
+        && this.name.equals(other.name)
+        && this.platformScope == other.platformScope;
   }
 }

--- a/src/main/java/com/komentum/designcomponent/domain/ComponentType.java
+++ b/src/main/java/com/komentum/designcomponent/domain/ComponentType.java
@@ -1,6 +1,7 @@
 package com.komentum.designcomponent.domain;
 
 import com.komentum.designcomponent.dto.ComponentTypeUpdateRequest;
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.TypeCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,6 +43,14 @@ public class ComponentType {
   @Column(nullable = false)
   private String name;
 
+  /**
+   * 이 component type이 공통으로 사용되는지, 특정 플랫폼 전용인지를 나타낸다.
+   */
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  @Column(name = "platform_scope", nullable = false)
+  private PlatformScope platformScope = PlatformScope.COMMON;
+
   @CreationTimestamp
   @Column(name = "created_at", updatable = false)
   private LocalDateTime createdAt;
@@ -60,12 +69,16 @@ public class ComponentType {
     if (componentType.getName() != null) {
       this.name = componentType.getName();
     }
+    if (componentType.getPlatformScope() != null) {
+      this.platformScope = componentType.getPlatformScope();
+    }
   }
 
   public void replace(ComponentType componentType) {
     this.explain = componentType.getExplain();
     this.name = componentType.getName();
     this.typeCode = componentType.getTypeCode();
+    this.platformScope = componentType.getPlatformScope();
   }
 
   public boolean isSame(ComponentType other) {
@@ -74,6 +87,7 @@ public class ComponentType {
     }
     return Objects.equals(this.explain, other.explain)
         && this.typeCode.equals(other.typeCode)
-        && this.name.equals(other.name);
+        && this.name.equals(other.name)
+        && this.platformScope == other.platformScope;
   }
 }

--- a/src/main/java/com/komentum/designcomponent/dto/ColorStyleCreateDto.java
+++ b/src/main/java/com/komentum/designcomponent/dto/ColorStyleCreateDto.java
@@ -1,5 +1,6 @@
 package com.komentum.designcomponent.dto;
 
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.StyleCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -27,4 +28,8 @@ public class ColorStyleCreateDto {
   @NotNull
   @Schema(description = "color style의 종류")
   private StyleCode styleCode;
+
+  @NotNull(message = "플랫폼 구분은 필수입니다")
+  @Schema(description = "생성할 color style이 공통/Android/iOS 중 어디에 속하는지, not null")
+  private PlatformScope platformScope;
 }

--- a/src/main/java/com/komentum/designcomponent/dto/ColorStyleResponse.java
+++ b/src/main/java/com/komentum/designcomponent/dto/ColorStyleResponse.java
@@ -1,5 +1,6 @@
 package com.komentum.designcomponent.dto;
 
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.StyleCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -26,4 +27,7 @@ public class ColorStyleResponse {
   // API 응답 시 enum name 대신 styleCode string 사용 ( @JsonValue )
   @Schema(description = "color style 종류")
   private StyleCode styleCode;
+
+  @Schema(description = "color style이 공통/Android/iOS 중 어디에 속하는지")
+  private PlatformScope platformScope;
 }

--- a/src/main/java/com/komentum/designcomponent/dto/ColorStyleUpdateRequest.java
+++ b/src/main/java/com/komentum/designcomponent/dto/ColorStyleUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.komentum.designcomponent.dto;
 
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.StyleCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -22,4 +23,7 @@ public class ColorStyleUpdateRequest {
 
   @Schema(description = "수정할 color style 종류, null 허용")
   private StyleCode styleCode;
+
+  @Schema(description = "수정할 color style이 공통/Android/iOS 중 어디에 속하는지, null 허용")
+  private PlatformScope platformScope;
 }

--- a/src/main/java/com/komentum/designcomponent/dto/ComponentTypeCreateRequest.java
+++ b/src/main/java/com/komentum/designcomponent/dto/ComponentTypeCreateRequest.java
@@ -1,5 +1,6 @@
 package com.komentum.designcomponent.dto;
 
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.TypeCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -29,4 +30,8 @@ public class ComponentTypeCreateRequest {
   @NotNull(message = "타입 정보는 필수입니다")
   @Schema(description = "생성할 component type의 종류, not null")
   private TypeCode typeCode;
+
+  @NotNull(message = "플랫폼 구분은 필수입니다")
+  @Schema(description = "생성할 component type이 공통/Android/iOS 중 어디에 속하는지, not null")
+  private PlatformScope platformScope;
 }

--- a/src/main/java/com/komentum/designcomponent/dto/ComponentTypeDto.java
+++ b/src/main/java/com/komentum/designcomponent/dto/ComponentTypeDto.java
@@ -1,5 +1,6 @@
 package com.komentum.designcomponent.dto;
 
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.TypeCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -27,6 +28,9 @@ public class ComponentTypeDto {
   // API 응답 시 enum name 대신 typeCode string 사용 ( @JsonValue )
   @Schema(description = "component type의 종류")
   private TypeCode typeCode;
+
+  @Schema(description = "component type이 공통/Android/iOS 중 어디에 속하는지")
+  private PlatformScope platformScope;
 
   @Schema(description = "component type의 생성일", example = "yyyy-MM-dd'T'HH:mm:ss")
   private LocalDateTime createdAt;

--- a/src/main/java/com/komentum/designcomponent/dto/ComponentTypeUpdateRequest.java
+++ b/src/main/java/com/komentum/designcomponent/dto/ComponentTypeUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.komentum.designcomponent.dto;
 
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.TypeCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -28,4 +29,7 @@ public class ComponentTypeUpdateRequest {
   @NotNull(message = "타입 정보는 필수입니다")
   @Schema(description = "수정할 component type의 종류, not null")
   private TypeCode typeCode;
+
+  @Schema(description = "수정할 component type이 공통/Android/iOS 중 어디에 속하는지, null 허용")
+  private PlatformScope platformScope;
 }

--- a/src/main/java/com/komentum/designcomponent/enums/PlatformScope.java
+++ b/src/main/java/com/komentum/designcomponent/enums/PlatformScope.java
@@ -1,0 +1,57 @@
+package com.komentum.designcomponent.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+
+/**
+ * 플랫폼 적용 범위를 나타낸다.
+ *
+ * <p>
+ * {@link Platform}은 어떤 플랫폼에 속하는지를 나타내고,
+ * PlatformScope는 해당 요소가 모든 플랫폼에서 공통으로 사용되는지
+ * 특정 플랫폼에 종속되는지를 나타낸다.
+ * </p>
+ *
+ * <p>
+ * Platform과 별도로 존재하는 이유는 공통 여부와 대상 플랫폼이 서로 다른 의미를 가지기 때문이다.
+ * 공통 요소를 Platform.COMMON으로 표현하면 플랫폼을 나타내는 {@link Platform}의 의미가 혼재될 수 있다.
+ * </p>
+ */
+public enum PlatformScope {
+  COMMON("common"),
+  ANDROID("android"),
+  IOS("ios");
+
+  private final String scopeName;
+
+  PlatformScope(String scopeName) {
+    this.scopeName = scopeName;
+  }
+
+  @JsonValue
+  public String getScopeName() {
+    return scopeName;
+  }
+
+  /**
+   * 이 scope의 데이터가 파라미터로 전달된 platform에서 사용될 수 있는지 확인한다.
+   * COMMON은 모든 플랫폼에서 사용 가능하며, ANDROID/IOS는 동일한 플랫폼에서만 사용 가능하다.
+   *
+   * @param platform 대상 플랫폼
+   * @return 사용 가능 여부
+   */
+  public boolean supports(Platform platform) {
+    if (this == COMMON) {
+      return true;
+    }
+    return this.name().equals(platform.name());
+  }
+
+  public static PlatformScope fromString(String platformScope) {
+    return Arrays.stream(values())
+        .filter(scope -> scope.name().equalsIgnoreCase(platformScope)
+            || scope.scopeName.equalsIgnoreCase(platformScope))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Invalid platform scope: " + platformScope));
+  }
+}

--- a/src/main/java/com/komentum/designcomponent/service/seeder/ColorStyleSeeder.java
+++ b/src/main/java/com/komentum/designcomponent/service/seeder/ColorStyleSeeder.java
@@ -3,6 +3,7 @@ package com.komentum.designcomponent.service.seeder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.komentum.designcomponent.domain.ColorStyle;
 import com.komentum.designcomponent.dto.SeedResult;
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.StyleCode;
 import com.komentum.designcomponent.repository.ColorStyleRepository;
 import com.komentum.global.utils.JsonUtils;
@@ -47,7 +48,20 @@ public class ColorStyleSeeder extends AbstractMapJsonSeeder<ColorStyle> {
         .styleCode(StyleCode.from(key))
         .name(node.path("name").asText())
         .explain(node.path("description").asText())
+        .platformScope(resolvePlatformScope(node))
         .build();
+  }
+
+  /**
+   * seed 노드의 platform 필드를 읽어 PlatformScope로 변환한다.
+   * 필드가 없으면 공통(COMMON)으로 취급한다.
+   */
+  private PlatformScope resolvePlatformScope(JsonNode node) {
+    String platform = node.path("platform").asText(null);
+    if (platform == null || platform.isBlank()) {
+      return PlatformScope.COMMON;
+    }
+    return PlatformScope.fromString(platform);
   }
 
   /**

--- a/src/main/java/com/komentum/designcomponent/service/seeder/ComponentTypeSeeder.java
+++ b/src/main/java/com/komentum/designcomponent/service/seeder/ComponentTypeSeeder.java
@@ -3,6 +3,7 @@ package com.komentum.designcomponent.service.seeder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.komentum.designcomponent.domain.ComponentType;
 import com.komentum.designcomponent.dto.SeedResult;
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.TypeCode;
 import com.komentum.designcomponent.repository.ComponentTypeRepository;
 import com.komentum.global.utils.JsonUtils;
@@ -46,7 +47,20 @@ public class ComponentTypeSeeder extends AbstractMapJsonSeeder<ComponentType> {
         .typeCode(TypeCode.from(key))
         .name(node.path("name").asText())
         .explain(node.path("description").asText())
+        .platformScope(resolvePlatformScope(node))
         .build();
+  }
+
+  /**
+   * seed 노드의 platform 필드를 읽어 PlatformScope로 변환한다.
+   * 필드가 없으면 공통(COMMON)으로 취급한다.
+   */
+  private PlatformScope resolvePlatformScope(JsonNode node) {
+    String platform = node.path("platform").asText(null);
+    if (platform == null || platform.isBlank()) {
+      return PlatformScope.COMMON;
+    }
+    return PlatformScope.fromString(platform);
   }
 
   /**

--- a/src/main/java/com/komentum/global/utils/RegexValidator.java
+++ b/src/main/java/com/komentum/global/utils/RegexValidator.java
@@ -4,8 +4,9 @@ import java.util.regex.Pattern;
 
 public class RegexValidator {
 
-  private static final Pattern HEX_COLOR_PATTERN =
-      Pattern.compile("^#?[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$");
+  public static final String HEX_COLOR_REGEX = "^#?[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$";
+
+  private static final Pattern HEX_COLOR_PATTERN = Pattern.compile(HEX_COLOR_REGEX);
 
   public static boolean isValidHexColor(String hexColor) {
     return hexColor != null && HEX_COLOR_PATTERN.matcher(hexColor).matches();

--- a/src/main/java/com/komentum/theme/android/dto/AndroidColorDto.java
+++ b/src/main/java/com/komentum/theme/android/dto/AndroidColorDto.java
@@ -19,7 +19,7 @@ public class AndroidColorDto {
   public static AndroidColorDto fromEntity(ThemeStyle themeStyle,
       PlatformColorStyle platformColorStyle) {
     return AndroidColorDto.builder()
-        .color(themeStyle.getColor())
+        .color(themeStyle.getColorWithAlphaArgb())
         .attrName(platformColorStyle.getResourceName())
         .build();
   }

--- a/src/main/java/com/komentum/theme/android/service/AndroidThemeGenerator.java
+++ b/src/main/java/com/komentum/theme/android/service/AndroidThemeGenerator.java
@@ -126,7 +126,11 @@ public class AndroidThemeGenerator {
    */
   private void applyThemeImages(Integer themeId) {
     // themeImage, platformComponentType 조회
-    List<ThemeImage> themeImageList = themeImageRepository.fetchJoinAllByThemeComponentId(themeId);
+    List<ThemeImage> themeImageList = themeImageRepository.fetchJoinAllByThemeComponentId(themeId)
+        .stream()
+        .filter(themeImage -> themeImage.getComponentType().getPlatformScope()
+            .supports(Platform.ANDROID))
+        .toList();
     Map<TypeCode, List<PlatformComponentType>> platformComponentTypeMap = platformComponentTypeRepository
         .fetchJoinAllByPlatform(Platform.ANDROID)
         .stream().collect(Collectors.groupingBy(
@@ -158,7 +162,11 @@ public class AndroidThemeGenerator {
    */
   private void applyThemeStyles(Integer themeId) {
     // themeImage, platformColorStyle 조회
-    List<ThemeStyle> themeStyleList = themeStyleRepository.fetchJoinAllByThemeComponentId(themeId);
+    List<ThemeStyle> themeStyleList = themeStyleRepository.fetchJoinAllByThemeComponentId(themeId)
+        .stream()
+        .filter(themeStyle -> themeStyle.getColorStyle().getPlatformScope()
+            .supports(Platform.ANDROID))
+        .toList();
     Map<StyleCode, List<PlatformColorStyle>> platformColorStyleMap = platformColorStyleRepository
         .fetchJoinAllByPlatform(Platform.ANDROID)
         .stream().collect(Collectors.groupingBy(

--- a/src/main/java/com/komentum/theme/core/domain/ThemeStyle.java
+++ b/src/main/java/com/komentum/theme/core/domain/ThemeStyle.java
@@ -1,6 +1,7 @@
 package com.komentum.theme.core.domain;
 
 import com.komentum.designcomponent.domain.ColorStyle;
+import com.komentum.global.utils.RegexValidator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +30,10 @@ import lombok.Setter;
 @AllArgsConstructor
 public class ThemeStyle {
 
+  private static final int MIN_ALPHA = 0;
+  private static final int MAX_ALPHA = 100;
+  private static final int MAX_HEX_ALPHA = 255;
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long themeStyleId;
@@ -40,14 +46,86 @@ public class ThemeStyle {
   @JoinColumn(name = "color_style_id")
   private ColorStyle colorStyle;
 
+  @Setter(AccessLevel.NONE)
   @Column(name = "color")
   private String color;
+
+  /**
+   * 색상의 백분율 투명도(0~100). null을 허용하지 않으며 항상 color와 함께 관리된다.
+   */
+  @Setter(AccessLevel.NONE)
+  @Builder.Default
+  @Column(name = "alpha", nullable = false)
+  private Integer alpha = MAX_ALPHA;
 
   public static ThemeStyle copyOf(ThemeComponent targetTheme, ThemeStyle sourceStyle) {
     return ThemeStyle.builder()
         .themeComponent(targetTheme)
         .colorStyle(sourceStyle.getColorStyle())
         .color(sourceStyle.getColor())
+        .alpha(sourceStyle.getAlpha())
         .build();
+  }
+
+  /**
+   * 요청으로 전달된 color와 alpha 값으로 기존 스타일 값을 덮어쓴다.
+   * color와 alpha는 항상 함께 존재해야 하며, 어느 하나만 존재하는 상태는 허용하지 않는다.
+   *
+   * @param color 새로 적용할 색상 값 (null 불가)
+   * @param alpha 새로 적용할 백분율 투명도, 0~100 (null 불가)
+   * @throws IllegalArgumentException color 또는 alpha가 null이거나 alpha가 0~100 범위를 벗어난 경우
+   */
+  public void updateColorAndAlpha(String color, Integer alpha) {
+    if (color == null || alpha == null) {
+      throw new IllegalArgumentException("color and alpha must not be null and must be provided together");
+    }
+    if (alpha < MIN_ALPHA || alpha > MAX_ALPHA) {
+      throw new IllegalArgumentException("alpha must be between " + MIN_ALPHA + " and " + MAX_ALPHA);
+    }
+    this.color = color;
+    this.alpha = alpha;
+  }
+
+  /**
+   * 백분율 투명도(alpha)를 16진수 값으로 변환해 color에 적용한 iOS용 RGBA 색상 값을 반환한다.
+   * color가 null/공백이거나 유효한 hex 형식이 아니면 null을 반환한다.
+   *
+   * @return "#RRGGBBAA" 형식의 색상 문자열, 변환할 수 없으면 null
+   */
+  public String getColorWithAlphaRgba() {
+    String baseColor = extractBaseHexColor();
+    if (baseColor == null) {
+      return null;
+    }
+    return "#" + baseColor + toHexAlpha();
+  }
+
+  /**
+   * 백분율 투명도(alpha)를 16진수 값으로 변환해 color에 적용한 Android용 ARGB 색상 값을 반환한다.
+   * color가 null/공백이거나 유효한 hex 형식이 아니면 null을 반환한다.
+   *
+   * @return "#AARRGGBB" 형식의 색상 문자열, 변환할 수 없으면 null
+   */
+  public String getColorWithAlphaArgb() {
+    String baseColor = extractBaseHexColor();
+    if (baseColor == null) {
+      return null;
+    }
+    return "#" + toHexAlpha() + baseColor;
+  }
+
+  private String extractBaseHexColor() {
+    if (color == null || alpha == null || color.isBlank()
+        || !RegexValidator.isValidHexColor(color.trim())) {
+      return null;
+    }
+    String hex = color.trim();
+    hex = hex.startsWith("#") ? hex.substring(1) : hex;
+    return hex.substring(0, 6).toUpperCase();
+  }
+
+  private String toHexAlpha() {
+    int hexAlpha = Math.round(alpha * MAX_HEX_ALPHA / (float) MAX_ALPHA);
+    return String.format("%02X", hexAlpha);
   }
 }

--- a/src/main/java/com/komentum/theme/core/dto/ThemeDetailResponse.java
+++ b/src/main/java/com/komentum/theme/core/dto/ThemeDetailResponse.java
@@ -1,6 +1,7 @@
 package com.komentum.theme.core.dto;
 
 import com.komentum.designcomponent.domain.DesignComponent;
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.StyleCode;
 import com.komentum.designcomponent.enums.TypeCode;
 import java.util.Map;
@@ -26,11 +27,13 @@ public class ThemeDetailResponse {
 
     Integer designComponentId;
     String imageUrl;
+    PlatformScope platformScope;
 
-    public static TypeCodeInfo of(DesignComponent designComponent) {
+    public static TypeCodeInfo of(DesignComponent designComponent, PlatformScope platformScope) {
       return TypeCodeInfo.builder()
           .designComponentId(designComponent.getDesignComponentId())
           .imageUrl(designComponent.getImageUrl())
+          .platformScope(platformScope)
           .build();
     }
   }
@@ -43,9 +46,15 @@ public class ThemeDetailResponse {
   public static class StyleCodeInfo {
 
     String color;
+    Integer alpha;
+    PlatformScope platformScope;
 
-    public static StyleCodeInfo of(String color) {
-      return StyleCodeInfo.builder().color(color).build();
+    public static StyleCodeInfo of(String color, Integer alpha, PlatformScope platformScope) {
+      return StyleCodeInfo.builder()
+          .color(color)
+          .alpha(alpha)
+          .platformScope(platformScope)
+          .build();
     }
   }
 

--- a/src/main/java/com/komentum/theme/core/dto/ThemeUpdateRequest.java
+++ b/src/main/java/com/komentum/theme/core/dto/ThemeUpdateRequest.java
@@ -2,6 +2,12 @@ package com.komentum.theme.core.dto;
 
 import com.komentum.designcomponent.enums.StyleCode;
 import com.komentum.designcomponent.enums.TypeCode;
+import com.komentum.global.utils.RegexValidator;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,10 +39,18 @@ public class ThemeUpdateRequest {
   @AllArgsConstructor
   public static class ThemeStyleUpdateRequest {
 
+    @NotNull
+    @Pattern(regexp = RegexValidator.HEX_COLOR_REGEX, message = "color must be a valid hex color")
     String color;
+
+    @NotNull
+    @Min(0)
+    @Max(100)
+    Integer alpha;
   }
 
   String themeName;
   Map<TypeCode, ThemeImageUpdateRequest> typeCodes;
+  @Valid
   Map<StyleCode, ThemeStyleUpdateRequest> styleCodes;
 }

--- a/src/main/java/com/komentum/theme/core/service/ThemeImageService.java
+++ b/src/main/java/com/komentum/theme/core/service/ThemeImageService.java
@@ -57,7 +57,7 @@ public class ThemeImageService {
     Map<TypeCode, TypeCodeInfo> res = themeImages.stream()
         .collect(Collectors.toMap(
             ti -> ti.getComponentType().getTypeCode(),
-            ti -> TypeCodeInfo.of(ti.getDesignComponent())
+            ti -> TypeCodeInfo.of(ti.getDesignComponent(), ti.getComponentType().getPlatformScope())
         ));
     if (res.size() != TypeCode.values().length) {
       log.warn(

--- a/src/main/java/com/komentum/theme/core/service/ThemeStyleService.java
+++ b/src/main/java/com/komentum/theme/core/service/ThemeStyleService.java
@@ -33,7 +33,7 @@ public class ThemeStyleService {
     Map<StyleCode, StyleCodeInfo> res = themeStyles.stream()
         .collect(Collectors.toMap(
             ts -> ts.getColorStyle().getStyleCode(),
-            ts -> StyleCodeInfo.of(ts.getColor())
+            ts -> StyleCodeInfo.of(ts.getColor(), ts.getAlpha(), ts.getColorStyle().getPlatformScope())
         ));
     if (res.size() != StyleCode.values().length) {
       log.warn(

--- a/src/main/java/com/komentum/theme/core/service/ThemeStyleService.java
+++ b/src/main/java/com/komentum/theme/core/service/ThemeStyleService.java
@@ -2,6 +2,7 @@ package com.komentum.theme.core.service;
 
 import com.google.common.base.Functions;
 import com.komentum.designcomponent.enums.StyleCode;
+import com.komentum.global.exception.ResourceNotFoundException;
 import com.komentum.theme.core.domain.ThemeComponent;
 import com.komentum.theme.core.domain.ThemeStyle;
 import com.komentum.theme.core.dto.ThemeDetailResponse.StyleCodeInfo;
@@ -67,6 +68,13 @@ public class ThemeStyleService {
     themeStyleRepository.saveAll(targetThemeStyles);
   }
 
+  /**
+   * 요청으로 전달된 StyleCode별 color/alpha 값으로 기존 ThemeStyle을 덮어쓴다.
+   * color와 alpha는 항상 함께 존재해야 하며, updateRequestMap이 비어있으면 아무 것도 하지 않는다.
+   *
+   * @throws ResourceNotFoundException 요청에 포함된 StyleCode에 대응하는 ThemeStyle이 존재하지 않는 경우
+   * @throws IllegalArgumentException  요청 항목의 color 또는 alpha가 null이거나 alpha가 0~100 범위를 벗어난 경우
+   */
   @Transactional
   public void updateThemeStyles(
       int themeComponentId,
@@ -81,8 +89,16 @@ public class ThemeStyleService {
             Functions.identity())
         );
     updateRequestMap.forEach((styleCode, updateRequest) -> {
+      if (updateRequest == null) {
+        throw new IllegalArgumentException("style update request must not be null: " + styleCode);
+      }
       ThemeStyle themeStyle = themeStyleMap.get(styleCode);
-      themeStyle.setColor(updateRequest.getColor());
+      if (themeStyle == null) {
+        throw new ResourceNotFoundException(
+            "ThemeStyle not found for styleCode=" + styleCode
+                + ", themeComponentId=" + themeComponentId);
+      }
+      themeStyle.updateColorAndAlpha(updateRequest.getColor(), updateRequest.getAlpha());
     });
   }
 }

--- a/src/main/java/com/komentum/theme/ios/editor/IosThemeCssEditor.java
+++ b/src/main/java/com/komentum/theme/ios/editor/IosThemeCssEditor.java
@@ -73,7 +73,7 @@ public class IosThemeCssEditor {
       if (themeStyle == null) {
         continue;
       }
-      String color = normalizeCssColor(themeStyle.getColor());
+      String color = themeStyle.getColorWithAlphaRgba();
       if (color == null) {
         continue;
       }
@@ -115,27 +115,5 @@ public class IosThemeCssEditor {
       return themeComponent.getVersionName();
     }
     return themeComponent.getVersionNumber();
-  }
-
-  private String normalizeCssColor(String color) {
-    if (color == null || color.isBlank()) {
-      return null;
-    }
-    String normalized = color.trim();
-    if (normalized.matches("[0-9a-fA-F]{6}")) {
-      return "#" + normalized;
-    }
-    // 공통 테마의 8자리 색상은 RRGGBBAA 형식이다.
-    // 현재 iOS CSS에는 알파를 반영하지 않으므로 뒤의 AA를 제외한 #RRGGBB만 기록한다.
-    if (normalized.matches("[0-9a-fA-F]{8}")) {
-      return "#" + normalized.substring(0, 6);
-    }
-    if (normalized.matches("#[0-9a-fA-F]{8}")) {
-      return normalized.substring(0, 7);
-    }
-    if (normalized.matches("#[0-9a-fA-F]{6}")) {
-      return normalized;
-    }
-    return null;
   }
 }

--- a/src/main/java/com/komentum/theme/ios/editor/IosThemeMaker.java
+++ b/src/main/java/com/komentum/theme/ios/editor/IosThemeMaker.java
@@ -49,10 +49,17 @@ public class IosThemeMaker {
       validateAccess(themeComponent);
       // 연관 엔티티를 fetch join으로 먼저 조회한 뒤,
       // 이미지 다운로드·파일 처리·업로드는 DB 트랜잭션 밖에서 수행한다.
+      // 공통 데이터와 iOS 전용 데이터만 사용하고, Android 전용 데이터는 제외한다.
       List<ThemeImage> themeImages =
-          themeImageService.fetchJoinThemeImagesByThemeComponentId(themeComponentId);
+          themeImageService.fetchJoinThemeImagesByThemeComponentId(themeComponentId).stream()
+              .filter(themeImage -> themeImage.getComponentType().getPlatformScope()
+                  .supports(Platform.IOS))
+              .toList();
       List<ThemeStyle> themeStyles =
-          themeStyleService.fetchJoinThemeStylesByThemeComponentId(themeComponentId);
+          themeStyleService.fetchJoinThemeStylesByThemeComponentId(themeComponentId).stream()
+              .filter(themeStyle -> themeStyle.getColorStyle().getPlatformScope()
+                  .supports(Platform.IOS))
+              .toList();
       List<PlatformComponentType> platformComponentTypes =
           platformComponentTypeRepository.fetchJoinAllByPlatform(Platform.IOS);
       List<PlatformColorStyle> platformColorStyles =

--- a/src/test/java/com/komentum/designcomponent/controller/ColorStyleControllerTest.java
+++ b/src/test/java/com/komentum/designcomponent/controller/ColorStyleControllerTest.java
@@ -11,6 +11,7 @@ import com.komentum.designcomponent.dto.ColorStyleCreateDto;
 import com.komentum.designcomponent.dto.ColorStyleResponse;
 import com.komentum.designcomponent.dto.ColorStyleUpdateRequest;
 import com.komentum.designcomponent.dto.SeedResult;
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.StyleCode;
 import com.komentum.designcomponent.repository.ColorStyleRepository;
 import com.komentum.designcomponent.service.seeder.ColorStyleSeeder;
@@ -76,12 +77,14 @@ public class ColorStyleControllerTest {
         .extracting(
             ColorStyle::getStyleCode,
             ColorStyle::getName,
-            ColorStyle::getExplain
+            ColorStyle::getExplain,
+            ColorStyle::getPlatformScope
         )
         .containsExactly(
             response.getStyleCode(),
             response.getName(),
-            response.getExplain()
+            response.getExplain(),
+            response.getPlatformScope()
         );
   }
 
@@ -116,6 +119,7 @@ public class ColorStyleControllerTest {
         .explain("test")
         .name("test")
         .styleCode(StyleCode.MAINVIEW_STYLE_BACKGROUND_COLOR)
+        .platformScope(PlatformScope.COMMON)
         .build();
     MockHttpServletRequestBuilder requestBuilder = mockMvcUtils.addAuthentication(
         MockMvcRequestBuilders
@@ -134,13 +138,42 @@ public class ColorStyleControllerTest {
         .extracting(
             ColorStyleResponse::getName,
             ColorStyleResponse::getStyleCode,
-            ColorStyleResponse::getExplain
+            ColorStyleResponse::getExplain,
+            ColorStyleResponse::getPlatformScope
         )
         .containsExactly(
             createRequest.getName(),
             createRequest.getStyleCode(),
-            createRequest.getExplain()
+            createRequest.getExplain(),
+            createRequest.getPlatformScope()
         );
+    assertColorStyleResponse(response);
+  }
+
+  @Test
+  @DisplayName("ColorStyle 생성 시 플랫폼 구분(platformScope)을 지정할 수 있다")
+  void createColorStyle_withIosPlatformScope_success() throws Exception {
+    // Given
+    ColorStyleCreateDto createRequest = ColorStyleCreateDto.builder()
+        .explain("iOS 전용 색상")
+        .name("ios color")
+        .styleCode(StyleCode.MAINVIEW_STYLE_BACKGROUND_COLOR)
+        .platformScope(PlatformScope.IOS)
+        .build();
+    MockHttpServletRequestBuilder requestBuilder = mockMvcUtils.addAuthentication(
+        MockMvcRequestBuilders
+            .post("/api/color-styles")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(createRequest)),
+        TestClientDto.fromEntity(rootUser)
+    );
+    // When
+    ColorStyleResponse response = mockMvcUtils.parseResponse(
+        mockMvc.perform(requestBuilder).andExpect(status().isOk()),
+        new TypeReference<>() {
+        });
+    // then
+    assertThat(response.getPlatformScope()).isEqualTo(PlatformScope.IOS);
     assertColorStyleResponse(response);
   }
 
@@ -203,6 +236,7 @@ public class ColorStyleControllerTest {
         .explain(UUID.randomUUID().toString())
         .name(UUID.randomUUID().toString())
         .styleCode(StyleCode.MAINVIEW_STYLE_BACKGROUND_COLOR)
+        .platformScope(PlatformScope.ANDROID)
         .build();
     // When
     ColorStyleResponse response = mockMvcUtils.doAuthRequest(
@@ -222,12 +256,14 @@ public class ColorStyleControllerTest {
         .extracting(
             ColorStyleResponse::getName,
             ColorStyleResponse::getStyleCode,
-            ColorStyleResponse::getExplain
+            ColorStyleResponse::getExplain,
+            ColorStyleResponse::getPlatformScope
         )
         .containsExactly(
             updateRequest.getName(),
             updateRequest.getStyleCode(),
-            updateRequest.getExplain()
+            updateRequest.getExplain(),
+            updateRequest.getPlatformScope()
         );
     assertColorStyleResponse(response);
   }

--- a/src/test/java/com/komentum/designcomponent/controller/ComponentTypeControllerTest.java
+++ b/src/test/java/com/komentum/designcomponent/controller/ComponentTypeControllerTest.java
@@ -9,6 +9,7 @@ import com.komentum.designcomponent.dto.ComponentTypeCreateRequest;
 import com.komentum.designcomponent.dto.ComponentTypeDto;
 import com.komentum.designcomponent.dto.ComponentTypeUpdateRequest;
 import com.komentum.designcomponent.dto.SeedResult;
+import com.komentum.designcomponent.enums.PlatformScope;
 import com.komentum.designcomponent.enums.TypeCode;
 import com.komentum.designcomponent.repository.ComponentTypeRepository;
 import com.komentum.designcomponent.service.seeder.ComponentTypeSeeder;
@@ -82,11 +83,13 @@ public class ComponentTypeControllerTest {
         .extracting(
             ComponentType::getTypeCode,
             ComponentType::getName,
-            ComponentType::getExplain)
+            ComponentType::getExplain,
+            ComponentType::getPlatformScope)
         .containsExactly(
             response.getTypeCode(),
             response.getName(),
-            response.getExplain());
+            response.getExplain(),
+            response.getPlatformScope());
   }
 
   public ComponentType createTestComponentType(TypeCode typeCode) {
@@ -106,6 +109,7 @@ public class ComponentTypeControllerTest {
         .explain("아이콘")
         .name("icon")
         .typeCode(TypeCode.CHAT_ROOM_BACKGROUND_IMAGE)
+        .platformScope(PlatformScope.COMMON)
         .build();
     // When
     ComponentTypeDto response = mockMvcUtils.doAuthRequest(
@@ -125,13 +129,43 @@ public class ComponentTypeControllerTest {
         .extracting(
             ComponentTypeDto::getExplain,
             ComponentTypeDto::getName,
-            ComponentTypeDto::getTypeCode
+            ComponentTypeDto::getTypeCode,
+            ComponentTypeDto::getPlatformScope
         )
         .containsExactly(
             request.getExplain(),
             request.getName(),
-            request.getTypeCode()
+            request.getTypeCode(),
+            request.getPlatformScope()
         );
+    assertComponentTypeDto(response);
+  }
+
+  @Test
+  @DisplayName("ComponentType 생성 시 플랫폼 구분(platformScope)을 지정할 수 있다")
+  void createComponentType_withAndroidPlatformScope_success() throws Exception {
+    // Given
+    ComponentTypeCreateRequest request = ComponentTypeCreateRequest.builder()
+        .explain("Android 전용 아이콘")
+        .name("android icon")
+        .typeCode(TypeCode.CHAT_ROOM_BACKGROUND_IMAGE)
+        .platformScope(PlatformScope.ANDROID)
+        .build();
+    // When
+    ComponentTypeDto response = mockMvcUtils.doAuthRequest(
+        MockMvcRequestDto.<ComponentTypeCreateRequest, ComponentTypeDto>builder()
+            .mockMvc(mockMvc)
+            .httpMethod(HttpMethod.POST)
+            .path("/api/component-types")
+            .clientDto(TestClientDto.fromEntity(client))
+            .body(request)
+            .statusCode(200)
+            .responseType(new TypeReference<>() {
+            })
+            .build()
+    );
+    // Then
+    assertThat(response.getPlatformScope()).isEqualTo(PlatformScope.ANDROID);
     assertComponentTypeDto(response);
   }
 
@@ -194,6 +228,7 @@ public class ComponentTypeControllerTest {
         .explain("수정된 컴포넌트")
         .name("updated icon")
         .typeCode(TypeCode.PASSCODE_BACKGROUND_IMAGE)
+        .platformScope(PlatformScope.IOS)
         .build();
     // When
     ComponentTypeDto response = mockMvcUtils.doAuthRequest(
@@ -213,12 +248,14 @@ public class ComponentTypeControllerTest {
         .extracting(
             ComponentTypeDto::getExplain,
             ComponentTypeDto::getName,
-            ComponentTypeDto::getTypeCode
+            ComponentTypeDto::getTypeCode,
+            ComponentTypeDto::getPlatformScope
         )
         .containsExactly(
             updateRequest.getExplain(),
             updateRequest.getName(),
-            updateRequest.getTypeCode()
+            updateRequest.getTypeCode(),
+            updateRequest.getPlatformScope()
         );
     assertComponentTypeDto(response);
   }

--- a/src/test/java/com/komentum/designcomponent/enums/PlatformScopeTest.java
+++ b/src/test/java/com/komentum/designcomponent/enums/PlatformScopeTest.java
@@ -1,0 +1,31 @@
+package com.komentum.designcomponent.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PlatformScopeTest {
+
+  @Test
+  @DisplayName("COMMON은 Android/iOS 플랫폼 모두를 지원한다")
+  void common_supportsAllPlatforms() {
+    assertThat(PlatformScope.COMMON.supports(Platform.ANDROID)).isTrue();
+    assertThat(PlatformScope.COMMON.supports(Platform.IOS)).isTrue();
+  }
+
+  @Test
+  @DisplayName("ANDROID는 Android 플랫폼만 지원한다")
+  void android_supportsOnlyAndroid() {
+    assertThat(PlatformScope.ANDROID.supports(Platform.ANDROID)).isTrue();
+    assertThat(PlatformScope.ANDROID.supports(Platform.IOS)).isFalse();
+  }
+
+  @Test
+  @DisplayName("IOS는 iOS 플랫폼만 지원한다")
+  void ios_supportsOnlyIos() {
+    assertThat(PlatformScope.IOS.supports(Platform.IOS)).isTrue();
+    assertThat(PlatformScope.IOS.supports(Platform.ANDROID)).isFalse();
+  }
+}

--- a/src/test/java/com/komentum/theme/controller/ThemeManageControllerTest.java
+++ b/src/test/java/com/komentum/theme/controller/ThemeManageControllerTest.java
@@ -147,6 +147,7 @@ class ThemeManageControllerTest {
     String expectedThemeName = UUID.randomUUID().toString();
     DesignComponent expectedImage = designComponentList.get(0);
     String expectedColor = "#FFFFFF";
+    Integer expectedAlpha = 80;
     ThemeUpdateRequest updateRequestDto = ThemeUpdateRequest.builder()
         .themeName(expectedThemeName)
         .typeCodes(Map.of(
@@ -159,6 +160,7 @@ class ThemeManageControllerTest {
             updatedStyleCode,
             ThemeStyleUpdateRequest.builder()
                 .color(expectedColor)
+                .alpha(expectedAlpha)
                 .build()
         ))
         .build();
@@ -185,6 +187,102 @@ class ThemeManageControllerTest {
     assertThat(updatedThemeImage.getDesignComponent().getDesignComponentId())
         .isEqualTo(expectedImage.getDesignComponentId());
     assertThat(updatedThemeStyle.getColor()).isEqualTo(expectedColor);
+    assertThat(updatedThemeStyle.getAlpha()).isEqualTo(expectedAlpha);
+  }
+
+  @Test
+  @DisplayName("color와 alpha 중 alpha 값이 유효 범위(0~100)를 벗어나면 테마 수정에 실패한다")
+  @Transactional
+  public void updateTheme_invalidAlphaRange_fail() throws Exception {
+    // given
+    ThemeComponent targetTheme = themeComponentScenarioSupport.builder(List.of(testUser),
+            designComponentList)
+        .withCountPerUser(1)
+        .build().themeComponents().get(0);
+    StyleCode updatedStyleCode = StyleCode.CHAT_ROOM_BACKGROUND_COLOR;
+    ThemeUpdateRequest updateRequestDto = ThemeUpdateRequest.builder()
+        .styleCodes(Map.of(
+            updatedStyleCode,
+            ThemeStyleUpdateRequest.builder()
+                .color("#FFFFFF")
+                .alpha(150)
+                .build()
+        ))
+        .build();
+    // when
+    MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put("/api/themes/{id}",
+        targetTheme.getThemeComponentId());
+    ResultActions resultActions = mockMvcUtils.performAuthRequest(request,
+        ExecutionContext.builder()
+            .mockMvc(mockMvc)
+            .body(updateRequestDto)
+            .clientDto(TestClientDto.fromEntity(testUser))
+            .build());
+    // then
+    resultActions.andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("color 값 없이 alpha 값만 전달되면 테마 수정에 실패한다")
+  @Transactional
+  public void updateTheme_colorMissing_fail() throws Exception {
+    // given
+    ThemeComponent targetTheme = themeComponentScenarioSupport.builder(List.of(testUser),
+            designComponentList)
+        .withCountPerUser(1)
+        .build().themeComponents().get(0);
+    StyleCode updatedStyleCode = StyleCode.CHAT_ROOM_BACKGROUND_COLOR;
+    ThemeUpdateRequest updateRequestDto = ThemeUpdateRequest.builder()
+        .styleCodes(Map.of(
+            updatedStyleCode,
+            ThemeStyleUpdateRequest.builder()
+                .alpha(80)
+                .build()
+        ))
+        .build();
+    // when
+    MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put("/api/themes/{id}",
+        targetTheme.getThemeComponentId());
+    ResultActions resultActions = mockMvcUtils.performAuthRequest(request,
+        ExecutionContext.builder()
+            .mockMvc(mockMvc)
+            .body(updateRequestDto)
+            .clientDto(TestClientDto.fromEntity(testUser))
+            .build());
+    // then
+    resultActions.andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("잘못된 형식의 color 값이 전달되면 테마 수정에 실패한다")
+  @Transactional
+  public void updateTheme_malformedColor_fail() throws Exception {
+    // given
+    ThemeComponent targetTheme = themeComponentScenarioSupport.builder(List.of(testUser),
+            designComponentList)
+        .withCountPerUser(1)
+        .build().themeComponents().get(0);
+    StyleCode updatedStyleCode = StyleCode.CHAT_ROOM_BACKGROUND_COLOR;
+    ThemeUpdateRequest updateRequestDto = ThemeUpdateRequest.builder()
+        .styleCodes(Map.of(
+            updatedStyleCode,
+            ThemeStyleUpdateRequest.builder()
+                .color("not-a-color")
+                .alpha(80)
+                .build()
+        ))
+        .build();
+    // when
+    MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put("/api/themes/{id}",
+        targetTheme.getThemeComponentId());
+    ResultActions resultActions = mockMvcUtils.performAuthRequest(request,
+        ExecutionContext.builder()
+            .mockMvc(mockMvc)
+            .body(updateRequestDto)
+            .clientDto(TestClientDto.fromEntity(testUser))
+            .build());
+    // then
+    resultActions.andExpect(status().isBadRequest());
   }
 
   @Test

--- a/src/test/java/com/komentum/theme/core/domain/ThemeStyleTest.java
+++ b/src/test/java/com/komentum/theme/core/domain/ThemeStyleTest.java
@@ -1,0 +1,105 @@
+package com.komentum.theme.core.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ThemeStyleTest {
+
+  @Test
+  @DisplayName("color와 alpha가 모두 전달되면 기존 값을 덮어쓴다")
+  void updateColorAndAlpha_overwritesExistingValues() {
+    // given
+    ThemeStyle themeStyle = ThemeStyle.builder()
+        .color("#000000")
+        .alpha(10)
+        .build();
+    // when
+    themeStyle.updateColorAndAlpha("#FFFFFF", 80);
+    // then
+    assertThat(themeStyle.getColor()).isEqualTo("#FFFFFF");
+    assertThat(themeStyle.getAlpha()).isEqualTo(80);
+  }
+
+  @Test
+  @DisplayName("color가 null이면 예외가 발생한다")
+  void updateColorAndAlpha_nullColor_throws() {
+    // given
+    ThemeStyle themeStyle = ThemeStyle.builder().color("#000000").alpha(10).build();
+    // when & then
+    assertThatThrownBy(() -> themeStyle.updateColorAndAlpha(null, 80))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("alpha가 null이면 예외가 발생한다")
+  void updateColorAndAlpha_nullAlpha_throws() {
+    // given
+    ThemeStyle themeStyle = ThemeStyle.builder().color("#000000").alpha(10).build();
+    // when & then
+    assertThatThrownBy(() -> themeStyle.updateColorAndAlpha("#FFFFFF", null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("alpha가 0~100 범위를 벗어나면 예외가 발생한다")
+  void updateColorAndAlpha_alphaOutOfRange_throws() {
+    // given
+    ThemeStyle themeStyle = ThemeStyle.builder().color("#000000").alpha(10).build();
+    // when & then
+    assertThatThrownBy(() -> themeStyle.updateColorAndAlpha("#FFFFFF", 101))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> themeStyle.updateColorAndAlpha("#FFFFFF", -1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("iOS용 RGBA 변환 시 alpha 백분율을 16진수로 변환해 color 뒤에 붙인다")
+  void getColorWithAlphaRgba_appendsHexAlphaAfterColor() {
+    // given
+    ThemeStyle fullyOpaque = ThemeStyle.builder().color("#FFFFFF").alpha(100).build();
+    ThemeStyle fullyTransparent = ThemeStyle.builder().color("#FFFFFF").alpha(0).build();
+    ThemeStyle halfAlpha = ThemeStyle.builder().color("#112233").alpha(50).build();
+    // when & then
+    assertThat(fullyOpaque.getColorWithAlphaRgba()).isEqualTo("#FFFFFFFF");
+    assertThat(fullyTransparent.getColorWithAlphaRgba()).isEqualTo("#FFFFFF00");
+    assertThat(halfAlpha.getColorWithAlphaRgba()).isEqualTo("#11223380");
+  }
+
+  @Test
+  @DisplayName("Android용 ARGB 변환 시 alpha 백분율을 16진수로 변환해 color 앞에 붙인다")
+  void getColorWithAlphaArgb_prependsHexAlphaBeforeColor() {
+    // given
+    ThemeStyle fullyOpaque = ThemeStyle.builder().color("#FFFFFF").alpha(100).build();
+    ThemeStyle fullyTransparent = ThemeStyle.builder().color("#FFFFFF").alpha(0).build();
+    ThemeStyle halfAlpha = ThemeStyle.builder().color("#112233").alpha(50).build();
+    // when & then
+    assertThat(fullyOpaque.getColorWithAlphaArgb()).isEqualTo("#FFFFFFFF");
+    assertThat(fullyTransparent.getColorWithAlphaArgb()).isEqualTo("#00FFFFFF");
+    assertThat(halfAlpha.getColorWithAlphaArgb()).isEqualTo("#80112233");
+  }
+
+  @Test
+  @DisplayName("color가 null/공백이거나 유효한 hex 형식이 아니면 변환 결과는 null이다")
+  void getColorWithAlpha_invalidColor_returnsNull() {
+    // given
+    ThemeStyle blankColor = ThemeStyle.builder().color(" ").alpha(80).build();
+    ThemeStyle malformedColor = ThemeStyle.builder().color("plum").alpha(80).build();
+    // when & then
+    assertThat(blankColor.getColorWithAlphaRgba()).isNull();
+    assertThat(blankColor.getColorWithAlphaArgb()).isNull();
+    assertThat(malformedColor.getColorWithAlphaRgba()).isNull();
+    assertThat(malformedColor.getColorWithAlphaArgb()).isNull();
+  }
+
+  @Test
+  @DisplayName("빌더로 alpha를 지정하지 않으면 기본값 100(불투명)이 적용된다")
+  void builderDefault_alphaIsFullyOpaque() {
+    // when
+    ThemeStyle themeStyle = ThemeStyle.builder().color("#FFFFFF").build();
+    // then
+    assertThat(themeStyle.getAlpha()).isEqualTo(100);
+  }
+}

--- a/src/test/java/com/komentum/theme/ios/editor/IosThemeCssEditorTest.java
+++ b/src/test/java/com/komentum/theme/ios/editor/IosThemeCssEditorTest.java
@@ -74,7 +74,7 @@ class IosThemeCssEditorTest {
     assertThat(result).contains("-kakaotalk-theme-version: '1.2.3';");
     assertThat(result).contains("-kakaotalk-author-name: 'owner@test.com';");
     assertThat(result).contains("-kakaotalk-theme-id: 'com.komentum.theme.ios.t7';");
-    assertThat(result).contains("background-color: #112233;");
+    assertThat(result).contains("background-color: #112233FF;");
   }
 
   @Test
@@ -123,7 +123,57 @@ class IosThemeCssEditorTest {
 
     // then
     String result = Files.readString(tempDir.resolve("KakaoTalkTheme.css"), StandardCharsets.UTF_8);
-    assertThat(result).contains("background-color: #112233;");
+    assertThat(result).contains("background-color: #112233FF;");
+  }
+
+  @Test
+  void editCss_appliesStoredAlphaAsRgbaSuffix() throws Exception {
+    // given
+    String css = """
+        ManifestStyle
+        {
+            -kakaotalk-theme-name: 'Apeach';
+            -kakaotalk-theme-version: '25.8.0';
+            -kakaotalk-author-name: 'Kakao Corp.';
+            -kakaotalk-theme-id: 'com.kakao.talk.theme.apeachios';
+        }
+        MainViewStyle-Primary
+        {
+            background-color: #FFDEDE;
+        }
+        """;
+    Files.writeString(tempDir.resolve("KakaoTalkTheme.css"), css, StandardCharsets.UTF_8);
+    ThemeComponent themeComponent = ThemeComponent.builder()
+        .themeComponentId(7)
+        .themeName("My Theme")
+        .userEmail("owner@test.com")
+        .versionName("1.2.3")
+        .versionNumber("12")
+        .build();
+    ColorStyle colorStyle = ColorStyle.builder()
+        .colorStyleId(1)
+        .styleCode(StyleCode.MAINVIEW_STYLE_BACKGROUND_COLOR)
+        .name("background")
+        .build();
+    ThemeStyle themeStyle = ThemeStyle.builder()
+        .colorStyle(colorStyle)
+        .color("#112233")
+        .alpha(50)
+        .build();
+    PlatformColorStyle platformColorStyle = PlatformColorStyle.builder()
+        .platform(Platform.IOS)
+        .colorStyle(colorStyle)
+        .resourceGroup("MainViewStyle-Primary")
+        .resourceName("background-color")
+        .code("test")
+        .build();
+
+    // when
+    editor.editCss(tempDir, themeComponent, List.of(themeStyle), List.of(platformColorStyle));
+
+    // then : alpha 50% -> round(50 * 255 / 100) = 128 = 0x80, RGBA 순서로 색상 뒤에 붙는다
+    String result = Files.readString(tempDir.resolve("KakaoTalkTheme.css"), StandardCharsets.UTF_8);
+    assertThat(result).contains("background-color: #11223380;");
   }
 
   @Test
@@ -172,7 +222,7 @@ class IosThemeCssEditorTest {
 
     // then
     String result = Files.readString(tempDir.resolve("KakaoTalkTheme.css"), StandardCharsets.UTF_8);
-    assertThat(result).contains("-ios-text-color: #123456;");
+    assertThat(result).contains("-ios-text-color: #123456FF;");
   }
 
   @Test

--- a/src/test/java/com/komentum/theme/ios/editor/IosThemeMakerTest.java
+++ b/src/test/java/com/komentum/theme/ios/editor/IosThemeMakerTest.java
@@ -3,21 +3,33 @@ package com.komentum.theme.ios.editor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.komentum.designcomponent.domain.ColorStyle;
+import com.komentum.designcomponent.domain.ComponentType;
+import com.komentum.designcomponent.enums.PlatformScope;
+import com.komentum.designcomponent.enums.StyleCode;
+import com.komentum.designcomponent.enums.TypeCode;
 import com.komentum.designcomponent.repository.PlatformColorStyleRepository;
 import com.komentum.designcomponent.repository.PlatformComponentTypeRepository;
 import com.komentum.global.domain.policy.OwnerAdminPolicy;
 import com.komentum.theme.core.domain.ThemeComponent;
+import com.komentum.theme.core.domain.ThemeImage;
+import com.komentum.theme.core.domain.ThemeStyle;
 import com.komentum.theme.core.service.ThemeImageService;
 import com.komentum.theme.core.service.ThemeRetrieveService;
 import com.komentum.theme.core.service.ThemeStyleService;
+import com.komentum.theme.ios.dto.IosThemePackageResponse;
 import com.komentum.user.domain.User;
 import com.komentum.user.service.UserEntityFinder;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -111,5 +123,73 @@ class IosThemeMakerTest {
         iosThemeImageEditor,
         iosThemeSaver
     );
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void makeTheme_excludesDataExclusiveToOtherPlatforms() throws Exception {
+    // given
+    int themeComponentId = 9;
+    String ownerEmail = "owner@test.com";
+    ThemeComponent themeComponent = ThemeComponent.builder()
+        .themeComponentId(themeComponentId)
+        .userEmail(ownerEmail)
+        .build();
+    User themeOwner = User.builder()
+        .publicUserId("owner-public-id")
+        .userEmail(ownerEmail)
+        .build();
+    ColorStyle commonColorStyle = ColorStyle.builder()
+        .colorStyleId(1)
+        .styleCode(StyleCode.MAINVIEW_STYLE_BACKGROUND_COLOR)
+        .platformScope(PlatformScope.COMMON)
+        .build();
+    ColorStyle iosColorStyle = ColorStyle.builder()
+        .colorStyleId(2)
+        .styleCode(StyleCode.FEATURE_STYLE_TEXT_COLOR)
+        .platformScope(PlatformScope.IOS)
+        .build();
+    ColorStyle androidOnlyColorStyle = ColorStyle.builder()
+        .colorStyleId(3)
+        .styleCode(StyleCode.TABBAR_STYLE_BACKGROUND_COLOR)
+        .platformScope(PlatformScope.ANDROID)
+        .build();
+    ThemeStyle commonStyle = ThemeStyle.builder().colorStyle(commonColorStyle).color("#111111")
+        .build();
+    ThemeStyle iosStyle = ThemeStyle.builder().colorStyle(iosColorStyle).color("#222222").build();
+    ThemeStyle androidOnlyStyle = ThemeStyle.builder().colorStyle(androidOnlyColorStyle)
+        .color("#333333").build();
+    ComponentType commonType = ComponentType.builder()
+        .componentTypeId(1)
+        .typeCode(TypeCode.PASSCODE_BACKGROUND_IMAGE)
+        .platformScope(PlatformScope.COMMON)
+        .build();
+    ComponentType androidOnlyType = ComponentType.builder()
+        .componentTypeId(2)
+        .typeCode(TypeCode.CHAT_ROOM_BACKGROUND_IMAGE)
+        .platformScope(PlatformScope.ANDROID)
+        .build();
+    ThemeImage commonImage = ThemeImage.builder().componentType(commonType).build();
+    ThemeImage androidOnlyImage = ThemeImage.builder().componentType(androidOnlyType).build();
+    // stub
+    when(themeRetrieveService.getThemeEntityById(themeComponentId)).thenReturn(themeComponent);
+    when(userEntityFinder.findUserEntityByEmail(ownerEmail)).thenReturn(themeOwner);
+    when(ownerAdminPolicy.validate(themeOwner)).thenReturn(true);
+    when(themeStyleService.fetchJoinThemeStylesByThemeComponentId(themeComponentId))
+        .thenReturn(List.of(commonStyle, iosStyle, androidOnlyStyle));
+    when(themeImageService.fetchJoinThemeImagesByThemeComponentId(themeComponentId))
+        .thenReturn(List.of(commonImage, androidOnlyImage));
+    when(iosThemeSaver.save(eq(themeComponentId), any()))
+        .thenReturn(IosThemePackageResponse.builder().themeComponentId(themeComponentId).build());
+    // when
+    iosThemeMaker.makeTheme(themeComponentId);
+    // then : Android 전용 데이터(androidOnlyStyle, androidOnlyImage)는 제외되고 공통 + iOS 전용 데이터만 iOS 에디터에 전달된다
+    ArgumentCaptor<List<ThemeStyle>> styleCaptor = ArgumentCaptor.forClass(List.class);
+    verify(iosThemeCssEditor).editCss(any(), eq(themeComponent), styleCaptor.capture(), any());
+    assertThat(styleCaptor.getValue()).containsExactlyInAnyOrder(commonStyle, iosStyle);
+
+    ArgumentCaptor<List<ThemeImage>> imageCaptor = ArgumentCaptor.forClass(List.class);
+    verify(iosThemeImageEditor).editImages(any(), imageCaptor.capture(), any());
+    assertThat(imageCaptor.getValue()).containsExactly(commonImage);
   }
 }


### PR DESCRIPTION
## PR 타입
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update <!-- (formatting, local variables) -->
- [ ] Refactoring <!-- (no functional changes, no api changes) -->
- [ ] Other... Please describe:


## 작업 내용
- ColorStyle, ComponentType에 호환되는 Platform 정보 포함
  - common : 모든 플랫폼 호환
  - Android : Android만 호환
  - iOS : iOS만 호환
- ThemeImage에 alpha 속성 추가
- Android/iOS 테마 제작 기능에 ARGB/RGBA 색상 적용 기능 추가
- Android/iOS 테마 제작 시 호환되는 ColorStyle/ComponentType 목록 조회 및 반영하도록 개선 

## 주의사항
- DefaultThemeSeeder 개선 필요성
  - ColorStyle, ComponentType이 platform 정보를 갖게됨에 따라 DefaultThemeSeeder가 Android 테마에 특정됨
  - 따라서 이를 해결할 방향이 필요 ( 추후 다른 PR에서 진행할 예정 )
- 단위 테스트 코드 추가에 따른 fixture layer의 필요성
  - 단위 테스트 코드 추가에 따라 Entity 생성 방식이 여러 단위 테스트 클래스에 퍼져있음
  - 이에 따라 변경에 취약한 테스트 구조가 되었음
- CLAUDE.md
  - CLAUDE.md를 개인/팀 내 관리할지 고민해볼 필요가 있음
  - 개발자 간 AI 사용 방시이 다르기에, 섣불리 공통화하는 것은 지양해야한다고 생각함
  - 자세한 내용은 현재 PR 내 CLAUDE.md 확인하기 ( KG 유무 등 )
- iOS 테마 제작 기능 수동테스트
  - 현재 환경에서는 불가함
  - 따라서 추후 테스트 가능한 개발자가 진행해주면 좋음

관련 이슈: #154  

## 테스트 결과
### 1. 통합 테스트 결과
<img width="1261" height="850" alt="image" src="https://github.com/user-attachments/assets/790ffff4-dc7e-4de3-bde2-87fa01858708" />

### 2. 수동 테스트 결과 ( 투명도, 특정 플랫폼의 component type, color style 수정 기능 테스트 )
<img width="1254" height="596" alt="image" src="https://github.com/user-attachments/assets/8c314481-4c9a-4f28-9adc-5bf0e28f2e80" />

### 3. 수동 테스트 결과 ( Android 테마 ARGB 색상 반영 결과 )
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/798f4903-7ce0-47e5-bf0f-979565caa92e" />


## PR 체크리스트
- [ ] 커밋 메시지가 가이드라인을 따르는가
- [ ] 테스트 코드를 모두 통과하였는가
- [ ] 관련 이슈를 연결하였는가
